### PR TITLE
Minor cleanups

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ function getSuttaTitleById(id) {
 function displaySuttas(suttas) {
   suttaArea.innerHTML = `<ul>${suttas.map(sutta => {
     const parts = sutta.split(':');
-    const id = parts[0].trim();
+    // TODO review this logic once MN series is finished.
+    const id = parts[0].trim().replace(/\s+/g, '');
     const title = parts[1].trim();
     return `<li><a href="/?q=${id.toLowerCase()}">${id}: ${title}</a></li>`;
   }).join('')}</ul>`;
@@ -333,7 +334,7 @@ function buildSutta(slug) {
     .catch(error => {
       suttaArea.innerHTML = `<p>Sorry, "${decodeURIComponent(slug)}" is not a valid sutta citation.
 
-    Note: Suttas that are part of a series require that you enter the exact series. For example, <code>an1.1</code> will not work, but <code>an1.1-10</code> will.<br>`;
+    <br><br>Note: Make sure the citation code is correct. Otherwise try finding the sutta from the home page.<br>`;
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function displaySuttas(suttas) {
     const title = parts[1].trim();
     return `<li><a href="/?q=${id.toLowerCase()}">${id}: ${title}</a></li>`;
   }).join('')}</ul>`;
-  suttaArea.innerHTML += `<p>Note: Bhikkhu Sujato's copyright-free English translations at SuttaCentral have been modified for use in this site.</p>`;
+  suttaArea.innerHTML += `<p style="font-size: 14px;"><i>Bhikkhu Sujato's copyright-free English translations at SuttaCentral have been modified for use in this site.</i></p>`;
 
   //Add listener for download button
   document.getElementById('cacheButton').addEventListener('click', () => {

--- a/readMe.md
+++ b/readMe.md
@@ -1,1 +1,10 @@
 # HH suttas
+Link: https://suttas.hillsidehermitage.org
+
+## Licence
+The English translations are licensed under [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/) while the website itself is under the [Unlicense](https://choosealicense.com/licenses/unlicense/).
+
+## Contributing
+Pull requests (PRs) for corrections of typos or formatting issues are welcome.
+
+If you're interested in improving the website, it's recommended to work on an existing issue or open a new issue before beginning your work.

--- a/readMe.md
+++ b/readMe.md
@@ -1,7 +1,7 @@
 # HH suttas
 Link: https://suttas.hillsidehermitage.org
 
-## Licence
+## License
 The English translations are licensed under [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/) while the website itself is under the [Unlicense](https://choosealicense.com/licenses/unlicense/).
 
 ## Contributing

--- a/sw.js
+++ b/sw.js
@@ -355,7 +355,7 @@ const filesToCache = [
 const cacheName = 'hh-suttas-cache-v1';
 
 self.addEventListener('install', event => {
-  
+
   // event.waitUntil(
   //   caches.open(cacheName)
   //     .then(cache => cache.addAll(filesToCache))

--- a/sw.js
+++ b/sw.js
@@ -352,7 +352,7 @@ const filesToCache = [
 ];
 
 
-const cacheName = 'hh-suttas-cache-v1';
+const cacheName = 'hh-suttas-cache-v2';
 
 self.addEventListener('install', event => {
 


### PR DESCRIPTION
Closes #36 
- add License in readme
- Made message more relevant when user navigated to a sutta that doesn't exist
- updated cache name because my browser was still using the old sw.js (from a while back). It seems changing the cache name does the trick (and apparently should be updated whenever the sw.js is updated. Need to confirm this 100%)
- Removed space from citations from main page links
- clean up acknowledgement text