### PR TITLE
checkout gh-pages from main and force push

### DIFF
--- a/.github/workflows/buildTestDeploy.yml
+++ b/.github/workflows/buildTestDeploy.yml
@@ -67,9 +67,5 @@ jobs:
     - name: Merge to gh-pages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
-        git fetch origin gh-pages
-        git checkout gh-pages
-        git config user.email "action@github.com"
-        git config user.name "GitHub Action"
-        git merge --no-ff --allow-unrelated-histories -m "Merging changes from main after tests" origin/main
-        git push origin gh-pages
+        git checkout -b gh-pages origin/main
+        git push -f origin gh-pages


### PR DESCRIPTION
closes #49 

I'm still not exactly sure why there were conflicts in the merge operations (in theory new commits from `main` should just slot in on top of the last commit in `gh-pages`). Nonetheless, we now just take the current state of `main` as it force push it to `gh-pages`