### PR TITLE
Update utils.js

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -127,7 +127,13 @@ function handleTextSelection() {
   }
 
   const start = selection.anchorNode.parentNode;
-  const end = selection.focusNode.parentNode;
+  
+  let end;
+  if(selection.focusNode.parentNode.tagName == "ARTICLE"){
+    end = selection.focusNode;
+  else if(selection.focusNode.parentNode.tagName == "SPAN"){
+    end = selection.focusNode.parentNode;
+    
   if (start.classList.contains('comment-text') || end.classList.contains('comment-text')) {
     return; // Selection is within a comment text, do not show copy button
   }


### PR DESCRIPTION
Temporary fix for Issue #52 so the "Copy link" button doesn't go all the way down the page when an user highlights a paragraph by triple-clicking on the text when Pali isn't displayed.

Still need to find how to not select the next node with `focusNode` when highlighting this way so the "Copy link" goes directly under the supposedly selected node and not one node below