### PR TITLE
Fix Issue #82

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -28,6 +28,10 @@ function scrollToHash() {
             highlight = true;
           }
 
+          if(element.classList.contains("evam")){ //if element is line 1 of sutta text
+            element = element.querySelector('.segment'); //Go to child segment element instead of parent to apply .highlight
+          }
+          
           if (highlight) {
             element.classList.add("highlight")
           }
@@ -35,23 +39,24 @@ function scrollToHash() {
           if (element.id === endFullId) {
             break;
           }
-          
-          if(element.parentNode.classList.contains("evam")){
-            element = element.parentNode;
+
+          if(element.parentNode.classList.contains("evam")){ //if element is line 1 of sutta text
+            //Go back to the parentNode to continue going through siblings after applying .highlight to its child
+            element = element.parentNode; 
           }
 
-          if(element.parentNode.classList.contains("sutta-title")){
-            element = element.parentNode;
+          //if sutta-title contained in link, goes directly to line 1 of sutta text instead of looking for sibling
+          if(element.parentNode.classList.contains("sutta-title")){ 
+            element = document.getElementById("mn1:1.1");
           }
-          
-          if (element.nextElementSibling) {
+          else if (element.nextElementSibling) {
             element = element.nextElementSibling;
           }
           else if (parseFloat(startIdSuffix) < parseFloat(endIdSuffix)) {
             element = element.parentNode.nextElementSibling.firstElementChild
           }
         }
-
+        
         startElement.scrollIntoView();
       }
     } else {

--- a/js/utils.js
+++ b/js/utils.js
@@ -35,6 +35,11 @@ function scrollToHash() {
           if (element.id === endFullId) {
             break;
           }
+          
+          if(element.parentNode.classList.contains("evam")){
+            element = element.parentNode;
+          }
+          
           if (element.nextElementSibling) {
             element = element.nextElementSibling;
           }

--- a/js/utils.js
+++ b/js/utils.js
@@ -39,6 +39,10 @@ function scrollToHash() {
           if(element.parentNode.classList.contains("evam")){
             element = element.parentNode;
           }
+
+          if(element.parentNode.classList.contains("sutta-title")){
+            element = element.parentNode;
+          }
           
           if (element.nextElementSibling) {
             element = element.nextElementSibling;


### PR DESCRIPTION
Added conditions to move through siblings without catching errors and displaying a "page not found" text when the link hash contains references to the sutta title segment or to the first line of the sutta segment.

Edit: Might need a proper refactoring or rethinking of the suttas .html files later for a cleaner code