### PR TITLE
Fix Issue #82

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -19,41 +19,20 @@ function scrollToHash() {
       const endElement = document.getElementById(endFullId);
 
       if (startElement && endElement) {
-        let element = startElement;
         let highlight = false;
-
-        // Loop through sibling elements until the end element is reached
-        while (element) {
-          if (element.id === startFullId) {
+        var segments = document.getElementsByClassName("segment");
+        
+        for (const segment of segments) {
+          if (segment.id === startFullId){
             highlight = true;
           }
 
-          if(element.classList.contains("evam")){ //if element is line 1 of sutta text
-            element = element.querySelector('.segment'); //Go to child segment element instead of parent to apply .highlight
+          if (highlight) {
+            segment.classList.add("highlight");
           }
           
-          if (highlight) {
-            element.classList.add("highlight")
-          }
-
-          if (element.id === endFullId) {
+          if (segment.id === endFullId){
             break;
-          }
-
-          if(element.parentNode.classList.contains("evam")){ //if element is line 1 of sutta text
-            //Go back to the parentNode to continue going through siblings after applying .highlight to its child
-            element = element.parentNode; 
-          }
-
-          //if sutta-title contained in link, goes directly to line 1 of sutta text instead of looking for sibling
-          if(element.parentNode.classList.contains("sutta-title")){ 
-            element = document.getElementById("mn1:1.1");
-          }
-          else if (element.nextElementSibling) {
-            element = element.nextElementSibling;
-          }
-          else if (parseFloat(startIdSuffix) < parseFloat(endIdSuffix)) {
-            element = element.parentNode.nextElementSibling.firstElementChild
           }
         }
         


### PR DESCRIPTION
Modification of the process to search for the segments to highlight.

Before: We had to navigate through parent nodes, child nodes and sibling nodes and the code was getting a bit messy with multiple special conditions for title segment/last segment/special segments (as in Snp4.3).

Now: we first get all elements with class "segment" in an array and just navigate through this array to highlight desired segments.

Performance-wise there aren't many segments in each page so it is seamless and the code is way simpler that way.