### PR TITLE
Hide <h5> pali titles when toggling off pali

### DIFF
--- a/index.css
+++ b/index.css
@@ -255,6 +255,7 @@ dt {
 .hide-pali h2 .pli-lang,
 .hide-pali h3 .pli-lang,
 .hide-pali h4 .pli-lang,
+.hide-pali h5 .pli-lang,
 .hide-pali li .pli-lang {
   display: none !important;
 }


### PR DESCRIPTION
`<h5>` pali titles were still visible after hiding pali  
e.g. DN2