### PR TITLE
Fix files caching issue

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -180,7 +180,7 @@ function showNotification(message, duration = 3000) {
     document.body.appendChild(notificationBox);
   }
 
-  notificationBox.textContent = message;
+  notificationBox.innerHTML = message;
 
   // Show the notification with fade-in effect
   notificationBox.style.display = 'block';

--- a/sutta_catalog_manager.py
+++ b/sutta_catalog_manager.py
@@ -23,7 +23,7 @@ def split_id(s):
 
 def add_sutta(available_suttas, match, data, key):
     """Extract sutta title from data and add it to the list if present."""
-    sutta_title = data.get(key)
+    sutta_title = data.get(key).rstrip()
 
     if sutta_title:
         with open("authors.json", "r", encoding='utf-8') as authors, open("suttas/translation_en/headings.json", "r", encoding='utf-8') as headings:
@@ -175,10 +175,18 @@ def generate_corresponding_files_list(available_suttas, output_file):
 
     # Directories to cache
     directories_to_cache = ["./images", "./js", "./"]
+    files_to_cache = []
+
     for directory in directories_to_cache:
-        for root, _, files in os.walk(directory):
-            if 'git' not in root:
-                files_to_cache.extend([os.path.relpath(os.path.join(root, file), '.') for file in files])
+        if directory == "./":
+            for file in os.listdir(directory):
+                file_path = os.path.join(directory, file)
+                if os.path.isfile(file_path) and 'git' not in file_path:
+                    files_to_cache.append(os.path.relpath(file_path, '.'))
+        else:
+            for root, _, files in os.walk(directory):
+                if 'git' not in root:
+                    files_to_cache.extend([os.path.relpath(os.path.join(root, file), '.') for file in files])
 
     # Generate paths for each sutta using the refined function
     for sutta in available_suttas:

--- a/sw.js
+++ b/sw.js
@@ -20,41 +20,66 @@ fetch('files_to_cache.json')
   .catch(error => console.error('Error loading files_to_cache.json:', error));
 
 const cacheName = `hh-suttas-cache-${version}`;
+const BATCH_SIZE = 50;
+const MAX_RETRIES = 3; // Define max fetching retries for failed fetched batch
+const TIMEOUT = 5000; // Define max time waiting for fetch response before retry
 
 self.addEventListener('install', event => {
-  self.skipWaiting()
+  self.skipWaiting();
 });
 
 self.addEventListener('message', event => {
   if (event.data && event.data.action === 'cacheResources') {
-    caches.open(cacheName)
-      .then(cache => {
-        const batchSize = 200;
-        const addFilesInBatches = async (files) => {
-          for (let i = 0; i < files.length; i += batchSize) {
-            const batch = files.slice(i, i + batchSize);
-            const addPromises = batch.map(file => {
-              return cache.add(file).catch(() => {
-                console.error('Caching failed for resource:', file);
-              });
-            });
-            await Promise.all(addPromises);
-          }
-        };
-        return addFilesInBatches(filesToCache);
-      })
-      .then(() => {
-        self.clients.matchAll().then(clients => {
-          clients.forEach(client => {
-            client.postMessage({ action: 'cachingSuccess' });
-          });
-        });
-      })
-      .catch(error => {
-        console.error('Unexpected error:', error);
-      });
+    cacheFilesInBatches(filesToCache);
   }
 });
+
+async function cacheFilesInBatches(files) {
+  const cache = await caches.open(cacheName);
+  for (let i = 0; i < files.length; i += BATCH_SIZE) {
+    const batch = files.slice(i, i + BATCH_SIZE);
+    let retries = 0;
+    let success = false;
+
+    while (retries < MAX_RETRIES && !success) {
+      try {
+        await cacheBatchWithTimeout(cache, batch);
+        success = true;
+      } catch (error) {
+        retries++;
+        if (retries === MAX_RETRIES) {
+          notifyClients('cachingError');
+          return;
+        }
+      }
+    }
+  }
+  notifyClients('cachingSuccess');
+}
+
+function cacheBatchWithTimeout(cache, batch) {
+  return new Promise((resolve, reject) => {
+    let timeoutId = setTimeout(() => reject(new Error('Timeout')), TIMEOUT);
+
+    Promise.all(batch.map(file => cache.add(file).catch(() => {
+      console.error('Caching failed for resource:', file);
+      throw new Error('Fetch failed');
+    })))
+      .then(() => {
+        clearTimeout(timeoutId);
+        resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function notifyClients(action) {
+  self.clients.matchAll().then(clients => {
+    clients.forEach(client => {
+      client.postMessage({ action });
+    });
+  });
+}
 
 self.addEventListener('fetch', function (event) {
   if (!event.request.url.startsWith('http')) {
@@ -75,7 +100,6 @@ self.addEventListener('fetch', function (event) {
       })
       .catch(function () {
         // If fetch fails, try to get the response from cache
-        console.log("index.html:");
         return caches.match(event.request)
           .then(function (response) {
             // If found in cache, return response


### PR DESCRIPTION
closes #108 

The issue came from the fact that when the root dir was added to the directories to cache, it cached every subdirectories in it, so every dirs and files from the project were cached resulting in a large number of files being pulled at once and in fetches errors because the browser (??) couldn't keep up.

**Solution:** 
- Cache only files when the current processed dir is "./", otherwise cache all files and subdirs.


**Additional:** 
- Modified the caching logic in sw.js so the files are cached in batch in order to not face the same issue arising because too many files were fetched at once.