### PR TITLE
MN63 typo

### DIFF
--- a/suttas/translation_en/mn/mn63_translation-en-anigha.json
+++ b/suttas/translation_en/mn/mn63_translation-en-anigha.json
@@ -115,7 +115,7 @@
   "mn63:5.28": "",
   "mn63:5.29": "and whether the arrowhead was spiked, razor-tipped, barbed, made of iron or a calf’s tooth, or lancet-shaped.’ ",
   "mn63:5.30": "That man would still not have learned these things, and meanwhile they’d die. ",
-  "mn63:5.31": "In the same way, suppose someone was to say: ",
+  "mn63:5.31": "In the same way, suppose someone were to say: ",
   "mn63:5.32": "‘I will not lead the renunciate life under the Buddha until the Buddha declares to me ",
   "mn63:5.33": "that the world is eternal, or that the world is not eternal … ",
   "mn63:5.34": "or that after death a realized one neither still exists nor no longer exists.’ ",

--- a/suttas/translation_en/mn/mn63_translation-en-anigha.json
+++ b/suttas/translation_en/mn/mn63_translation-en-anigha.json
@@ -115,7 +115,7 @@
   "mn63:5.28": "",
   "mn63:5.29": "and whether the arrowhead was spiked, razor-tipped, barbed, made of iron or a calf’s tooth, or lancet-shaped.’ ",
   "mn63:5.30": "That man would still not have learned these things, and meanwhile they’d die. ",
-  "mn63:5.31": "In the same way, suppose someone were to say: ",
+  "mn63:5.31": "In the same way, suppose someone were to say this: ",
   "mn63:5.32": "‘I will not lead the renunciate life under the Buddha until the Buddha declares to me ",
   "mn63:5.33": "that the world is eternal, or that the world is not eternal … ",
   "mn63:5.34": "or that after death a realized one neither still exists nor no longer exists.’ ",


### PR DESCRIPTION
Also, is the comma positionning before the closing quotation mark made on purpose? E.g., ```‘the world is eternal,’ ‘the world is not eternal,’ ... ```