### PR TITLE
Fix Issue #113

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -60,7 +60,7 @@ function generateLink(idOrRange) {
     console.error("Invalid ID or Range format");
     return "";
   }
-  return `${baseUrl}?q=${hash.substring(1).split(':')[0]}${hash}`;
+  return `${baseUrl}?q=${suttaId}${hash}`;
 }
 
 function changeAcronymNumber(acronym, change) {
@@ -195,6 +195,18 @@ function showNotification(message, duration = 3000) {
     }, 500); // This duration should match the transition duration in the CSS
   }, duration);
 }
+
+function extractIdsFromUrl() {
+    const urlObj = new URL(window.location.href);
+    
+    // Use URLSearchParams to fetch 'q' parameter value in URL
+    const queryParams = new URLSearchParams(urlObj.search);
+    const qValue = queryParams.get('q');
+    
+    return qValue;
+}
+
+const suttaId = extractIdsFromUrl();
 
 // Add event listener for text selection
 document.addEventListener('selectionchange', handleTextSelection);


### PR DESCRIPTION
Issue #113 was about two issues:

1) For collections of suttas like AN.1.51-60, the sutta's IDs contained in the segments of the html aren't the same as the sutta id we are going to find in the url for the ```?q=``` parameter.
So when copying a link, the id extracted wasn't correct: instead of ```?q=an1.51-60```, we got ```?q=an1.51``` or ```?q=an1.52``` etc, depending on the segment copied.

2) Function ```generateLink()``` receive as a parameter the range of verses to link to, separated by a dash (e.g., ```mn11:4.1-mn11:4.5```), which was problematic when the first part of the verse contained a dash itself.

**Solution:**
Fetch the sutta's id in the current url when displaying the page and keep it in memory.
Fetch this id in generateLink() instead of reading it from the values in the range of verses.

@ishaanv Is this all good for you?