### PR TITLE
WIP: Go back to line displayed after text shift

### DIFF
--- a/index.css
+++ b/index.css
@@ -194,6 +194,10 @@ span.eng-lang {
   display: block;
 }
 
+span.eng-lang.scrolledTo{
+  transition: color 5s;
+}
+
 p,
 dt,
 li,

--- a/index.js
+++ b/index.js
@@ -84,6 +84,27 @@ function displaySuttas(suttas, isSearch = false) {
   }).join('')}</ul>`;
 }
 
+function getSegmentToHighlight(targetElement) {
+  // Check is we are placed on the very first segment of the current paragraph
+  // If not, return the ID of the first segment of the current paragraph
+  console.log(targetElement);
+  const parentParagraph = targetElement.closest('p');
+  var nextParagraph = null;
+  
+  if(parentParagraph != null)
+    nextParagraph = parentParagraph.nextElementSibling;
+  console.log("1");
+  console.log(parentParagraph);
+  console.log("2");
+  console.log(nextParagraph);
+  
+  if (nextParagraph && nextParagraph.tagName.toLowerCase() === 'p') {
+    const firstSegment = nextParagraph.querySelector('.segment');
+    return firstSegment;
+  }
+
+  return null;
+}
 
 function toggleThePali() {
   const hideButton = document.getElementById("hide-pali");
@@ -97,19 +118,22 @@ function toggleThePali() {
   hideButton.addEventListener("click", () => {
     // Triez les éléments par l'attribut id
     const sortedEntries = Object.entries(viewportEntries).sort((a, b) => {
-      return a[0].localeCompare(b[0]);
+      // Extraire la partie après les deux-points et la convertir en nombre
+      let numA = parseFloat(a[0].split(':')[1]);
+      let numB = parseFloat(b[0].split(':')[1]);
+      
+      // Comparer les nombres
+      return numA - numB;
     });
-
+    
     // If you need the sorted entries as an object again
     const sortedViewportEntries = Object.fromEntries(sortedEntries);
     
-    var idPos = 0;
-    if(Object.values(sortedViewportEntries).length > 3){
-      idPos = 2;
-    }
-    //Get the ID of the middlish segment currently displayed
+    var idPos = 1;
+    //Get the ID of a top segment currently displayed
     var firstSegmentId = Object.values(sortedViewportEntries)[idPos].id;
-    var firstSegmentShown = document.getElementById(firstSegmentId);
+    var firstSegment = document.getElementById(firstSegmentId);
+    var segmentToHighlight = getSegmentToHighlight(firstSegment);
     
     const previousScrollPosition = window.scrollY;
     if (localStorage.paliToggle === "show") {
@@ -121,21 +145,26 @@ function toggleThePali() {
       localStorage.paliToggle = "show";
     }
 
-    //Shows the previous displayed segment by temporarily modifying its color
-    const textElement = document.getElementById(firstSegmentId).getElementsByClassName('eng-lang')[0];
-    textElement.style.color = 'red';
-    setTimeout(function() {
-      textElement.classList.add("scrolledTo");
-      textElement.style.color = 'black';
-    }, 1000);
-    setTimeout(function() {
-        textElement.classList.remove("scrolledTo");
-    }, 6000);
-    //And scrolls back to the middlish segment that was currently displayed before the text shift caused by showing/hiding pali
-    firstSegmentShown.scrollIntoView({
-      behavior: 'smooth',
-      block: 'center'
-    });
+    if(segmentToHighlight){
+      //Shows the previous displayed segment by temporarily modifying its color
+      const textElement = document.getElementById(segmentToHighlight.id).getElementsByClassName('eng-lang')[0];
+      textElement.style.color = 'red';
+      setTimeout(function() {
+        textElement.classList.add("scrolledTo");
+        textElement.style.color = 'black';
+      }, 1000);
+      setTimeout(function() {
+          textElement.classList.remove("scrolledTo");
+      }, 6000);
+      
+      if(firstSegment){
+        //And scrolls back to the top segment that was currently displayed before the text shift caused by showing/hiding pali
+        firstSegment.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      }
+    }
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const forewordText = `Terms and expressions of doctrinal and practical significa
   (2) The tendency to translate the term <em>yoniso manasikāra</em> along the lines of “appropriate” or “wise” attention, evidently assuming the literal meaning of <em>yoniso</em> to be unimportant. However, there is no reason to think that the Buddha didn’t intentionally opt for this peculiar expression to describe <a href="https://suttas.hillsidehermitage.org/?q=mn2#mn2:3.1-mn2:3.3">what is arguably the core element of the practice</a>, and <a href="https://suttas.hillsidehermitage.org/?q=sn45.55">leads to the acquisition of the Noble Eightfold Path</a>.
   <br><br>
   On this site, Bhikkhu Sujato’s copyright-free translations have been adapted to create a work that rigorously aims to convey the meaning of significant Pāli terms drawing solely on their etymology—which is generally unambiguous—and eschewing commentarial and later baggage that is often present even in most Pāli dictionaries. Individual perspectives and explanations, along with the reasoning behind the chosen renderings for the infrequent less straightforward terms, have been left for the comments. This approach aims to maintain a clear distinction between translation and interpretation, which is often blurred.`;
+var viewportEntries = {};
 
 // functions
 
@@ -93,8 +94,9 @@ function toggleThePali() {
   }
   
   hideButton.addEventListener("click", () => {
-    //Get the ID of the first segment currently displayed
-    var firstSegmentShown = document.getElementById(Object.values(viewportEntries)[0].id);
+    //Get the ID of the middlish segment currently displayed
+    var firstSegmentId = Object.values(viewportEntries)[Math.floor(Object.values(viewportEntries).length/2)].id;
+    var firstSegmentShown = document.getElementById(firstSegmentId);
     
     const previousScrollPosition = window.scrollY;
     if (localStorage.paliToggle === "show") {
@@ -106,8 +108,21 @@ function toggleThePali() {
       localStorage.paliToggle = "show";
     }
 
-    //Scroll back to the first segment that was currently displayed before the text shift caused by showing/hiding pali
-    firstSegmentShown.scrollIntoView();
+    //Shows the previous displayed segment by temporarily modifying its color
+    const textElement = document.getElementById(firstSegmentId).getElementsByClassName('eng-lang')[0];
+    textElement.style.color = 'red';
+    setTimeout(function() {
+      textElement.classList.add("scrolledTo");
+      textElement.style.color = 'black';
+    }, 1000);
+    setTimeout(function() {
+        textElement.classList.remove("scrolledTo");
+    }, 6000);
+    //And scrolls back to the middlish segment that was currently displayed before the text shift caused by showing/hiding pali
+    firstSegmentShown.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center'
+    });
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const forewordText = `Terms and expressions of doctrinal and practical significa
   (2) The tendency to translate the term <em>yoniso manasikāra</em> along the lines of “appropriate” or “wise” attention, evidently assuming the literal meaning of <em>yoniso</em> to be unimportant. However, there is no reason to think that the Buddha didn’t intentionally opt for this peculiar expression to describe <a href="https://suttas.hillsidehermitage.org/?q=mn2#mn2:3.1-mn2:3.3">what is arguably the core element of the practice</a>, and <a href="https://suttas.hillsidehermitage.org/?q=sn45.55">leads to the acquisition of the Noble Eightfold Path</a>.
   <br><br>
   On this site, Bhikkhu Sujato’s copyright-free translations have been adapted to create a work that rigorously aims to convey the meaning of significant Pāli terms drawing solely on their etymology—which is generally unambiguous—and eschewing commentarial and later baggage that is often present even in most Pāli dictionaries. Individual perspectives and explanations, along with the reasoning behind the chosen renderings for the infrequent less straightforward terms, have been left for the comments. This approach aims to maintain a clear distinction between translation and interpretation, which is often blurred.`;
+
 var viewportEntries = {};
 
 // functions
@@ -94,8 +95,20 @@ function toggleThePali() {
   }
   
   hideButton.addEventListener("click", () => {
+    // Triez les éléments par l'attribut id
+    const sortedEntries = Object.entries(viewportEntries).sort((a, b) => {
+      return a[0].localeCompare(b[0]);
+    });
+
+    // If you need the sorted entries as an object again
+    const sortedViewportEntries = Object.fromEntries(sortedEntries);
+    
+    var idPos = 0;
+    if(Object.values(sortedViewportEntries).length > 3){
+      idPos = 2;
+    }
     //Get the ID of the middlish segment currently displayed
-    var firstSegmentId = Object.values(viewportEntries)[Math.floor(Object.values(viewportEntries).length/2)].id;
+    var firstSegmentId = Object.values(sortedViewportEntries)[idPos].id;
     var firstSegmentShown = document.getElementById(firstSegmentId);
     
     const previousScrollPosition = window.scrollY;

--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ function toggleThePali() {
   hideButton.addEventListener("click", () => {
     //Get the ID of the first segment currently displayed
     var firstSegmentShown = document.getElementById(Object.values(viewportEntries)[0].id);
-    console.log(firstSegmentShown);
     
     const previousScrollPosition = window.scrollY;
     if (localStorage.paliToggle === "show") {

--- a/index.js
+++ b/index.js
@@ -87,16 +87,11 @@ function displaySuttas(suttas, isSearch = false) {
 function getSegmentToHighlight(targetElement) {
   // Check is we are placed on the very first segment of the current paragraph
   // If not, return the ID of the first segment of the current paragraph
-  console.log(targetElement);
   const parentParagraph = targetElement.closest('p');
   var nextParagraph = null;
   
   if(parentParagraph != null)
     nextParagraph = parentParagraph.nextElementSibling;
-  console.log("1");
-  console.log(parentParagraph);
-  console.log("2");
-  console.log(nextParagraph);
   
   if (nextParagraph && nextParagraph.tagName.toLowerCase() === 'p') {
     const firstSegment = nextParagraph.querySelector('.segment');

--- a/index.js
+++ b/index.js
@@ -91,8 +91,12 @@ function toggleThePali() {
       localStorage.paliToggle = "hide";
       suttaArea.classList.add("hide-pali");
   }
-
+  
   hideButton.addEventListener("click", () => {
+    //Get the ID of the first segment currently displayed
+    var firstSegmentShown = document.getElementById(Object.values(viewportEntries)[0].id);
+    console.log(firstSegmentShown);
+    
     const previousScrollPosition = window.scrollY;
     if (localStorage.paliToggle === "show") {
       suttaArea.classList.add("hide-pali");
@@ -102,10 +106,9 @@ function toggleThePali() {
       suttaArea.classList.remove("hide-pali");
       localStorage.paliToggle = "show";
     }
-    setTimeout(() => {
-      const currentScrollPosition = window.scrollY;
-      window.scrollTo(0, currentScrollPosition - (previousScrollPosition - currentScrollPosition));
-    }, 0);
+
+    //Scroll back to the first segment that was currently displayed before the text shift caused by showing/hiding pali
+    firstSegmentShown.scrollIntoView();
   });
 }
 
@@ -320,6 +323,8 @@ function buildSutta(slug) {
       if (cacheButton) cacheButton.style.display = 'none';
       if (infoButton) infoButton.style.display = 'none';
 
+      initInterObs();
+      
       // scroll to the quote in the url if present
       scrollToHash();
     })
@@ -328,6 +333,35 @@ function buildSutta(slug) {
 
     <br><br>Note: Make sure the citation code is correct. Otherwise try finding the sutta from the home page.<br>`;
     });
+}
+
+//Initialize intersection observers so we know which segments were displayed before the text shift caused by displaying/hiding pali
+function initInterObs(){
+  // Select every elements with class "segment"
+  const segments = document.querySelectorAll('.segment');
+  
+  const intersectionCallback = (entries, observer) => {
+  	entries.forEach(entry => {
+  		if (entry.isIntersecting) {
+  			//Add element if in viewport
+  			viewportEntries[entry.target.id] = entry.target;
+  		} else {
+  			//Delete element if not in viewport anymore
+  			delete viewportEntries[entry.target.id];
+  		}
+  	});
+  };
+  
+  const observer = new IntersectionObserver(intersectionCallback, {
+  	root: null, // Use viewport as root
+  	rootMargin: '0px',
+  	threshold: 0.1
+  });
+  
+  // Observe on each segment
+  segments.forEach(segment => {
+  	observer.observe(segment);
+  });
 }
 
 function addNavbar() {


### PR DESCRIPTION
closes #119

- [x] Add IntersectionObserver and scroll to the latest first line displayed after text shift caused by showing/hiding pali
- [ ] Add a color indication fading away to indicate which line to look at after scrolling back to the correct part (not working properly when clicking multiple times in a row on the button, but might just be a case scenario that is not interesting us)
- [x] Improvements? (for now, takes the third top segment displayed on the viewport, might be impossible to know exactly which one to take into account since we can't eyetrack the user | I should probably just stick to take the very first displayed at the top and put this very first back at the top?)
- [x] ~~Can I just make "window.scrollTo();" to work reliably and skip the use of intersectionObserver?~~
- [x] Issue: the sorting does a text sorting and not a number sorting on the ID which causes an issue when having clicked the button to hide pali (e.g. places id finishing by x.10 before id finishing x.2)
- [ ] Doesn't work on suttas collections having ```<article>``` parent container instead of ```<p>``` like AN1.51-60
