### PR TITLE
Remove side-by-side when toggling pali off

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ function toggleThePali() {
       suttaArea.classList.add("hide-pali");
       localStorage.paliToggle = "hide";
       document.querySelector("body").classList.remove("side-by-side");
+      localStorage.sideBySide = "false";
     } else {
       suttaArea.classList.remove("hide-pali");
       localStorage.paliToggle = "show";


### PR DESCRIPTION
Remove side-by-side when toggling pali off to fix issue: 
when turning pali off on a page where side-by-side mode is activated -> titles on next visited pages were still showing side-by-side 

closes #145 