### PR TITLE
Fix issues with highlighting

### DIFF
--- a/index.css
+++ b/index.css
@@ -81,6 +81,7 @@ body.dark {
 .dark .comment-highlight{
   font-family: "RobotoSerif Medium";
   color: var(--white); /* White text for dark background */
+  font-size: 1.1rem;
 }
 
 .light .highlight {
@@ -90,6 +91,11 @@ body.dark {
 
 .light .comment-highlight{
   font-family: "RobotoSerif Medium";
+}
+
+.light .comment-highlight > span{
+  display: inline;
+  box-shadow: 0px 2px 3px rgba(0, 0, 0, .2);
 }
 
 .go-button {
@@ -203,6 +209,10 @@ p.sc-link {
 span.pli-lang,
 span.eng-lang {
   display: block;
+}
+
+.highlight > span.eng-lang{
+  display: inline;
 }
 
 p,

--- a/index.css
+++ b/index.css
@@ -215,6 +215,10 @@ span.eng-lang {
   display: inline;
 }
 
+.highlight > span.pli-lang {
+  margin-top: .4rem;
+}
+
 p,
 dt,
 li,

--- a/index.js
+++ b/index.js
@@ -341,11 +341,11 @@ function buildSutta(slug) {
             }
             // Inside the comment HTML
             commentsHtml += `
-            <p id="comment${commentCount}">
+            <p id="comment${commentCount}"><span>
               ${commentCount}: ${converter.makeHtml(comment_text[segment])
                 .replace(/^<p>(.*)<\/p>$/, '$1')}
               <a href="#${segment}~no-highlight" style="cursor: pointer; font-size: 14px;">&larr;</a>
-            </p>
+            </span></p>
             `;
   
             commentCount++;


### PR DESCRIPTION
- Fix box-shadow not showing on highlights when displaying pali: now it will show on the english part when pali is displayed.
- Add box-shadow on highlighted comments: had to add ```<span>``` elements around comments for it to work.
- Increase obviousness of highlights when in dark mode (box-shadow isn't used in dark mode) by increasing font-size.

closes #162 