### PR TITLE
Correct highlighting bug

### DIFF
--- a/index.css
+++ b/index.css
@@ -329,7 +329,7 @@ dt {
 }
 
 #sutta.hide-pali blockquote.gatha p span.verse-line span.eng-lang {
-  display: block !important;
+  display: inline-block !important;
   margin-bottom: 0rem;
 }
 


### PR DESCRIPTION
Correct highlighting bug where the box-shadow around the highlighted passage doesn't show on a blockquote like the one at the end of SN 35.94