### PR TITLE
Add Glossary page

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -20,7 +20,6 @@
     <meta property="og:site_name" content="suttas.hillsidehermitage.org" />
     <meta property="og:image" itemprop="image" content="https://suttas.hillsidehermitage.org/images/favicon.jpg" />
     <script defer src="js/showdown.min.js"></script>
-    <script defer src="js/fuse.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/bookmarks.html
+++ b/bookmarks.html
@@ -69,20 +69,13 @@
                 </svg>
             </div>
             <!-- <input id="citation" type="text" placeholder="Enter citation or search by title"> -->
-            <div id="home-button" class="icon-button">
+            <div id="home-button" class="icon-button" onclick="location.href='/'">
                 <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
                     <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
                         <path
                             d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
                             fill="currentColor" />
                     </g>
-                </svg>
-            </div>
-            <div id="theme-button" class="icon-button">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                    <path
-                        d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                        fill="currentColor" />
                 </svg>
             </div>
             <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'">
@@ -101,6 +94,20 @@
                   <g id="comment-icon">
                     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
                   </g>
+                </svg>
+            </div>
+            <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
+                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+                     class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
+                    <path d="M12 5v16" />
+                    <path d="M7 7h1" />
+                    <path d="M7 11h1" />
+                    <path d="M16 7h1" />
+                    <path d="M16 11h1" />
+                    <path d="M16 15h1" />
                 </svg>
             </div>
         </form>

--- a/comments.html
+++ b/comments.html
@@ -20,7 +20,6 @@
     <meta property="og:site_name" content="suttas.hillsidehermitage.org" />
     <meta property="og:image" itemprop="image" content="https://suttas.hillsidehermitage.org/images/favicon.jpg" />
     <script defer src="js/showdown.min.js"></script>
-    <script defer src="js/fuse.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/comments.html
+++ b/comments.html
@@ -69,20 +69,13 @@
             </svg>
         </div>
         <!-- <input id="citation" type="text" placeholder="Enter citation or search by title"> -->
-        <div id="home-button" class="icon-button">
+        <div id="home-button" class="icon-button" onclick="location.href='/'">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
                 <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
                     <path
                         d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
                         fill="currentColor" />
                 </g>
-            </svg>
-        </div>
-        <div id="theme-button" class="icon-button">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
             </svg>
         </div>
         <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'">
@@ -101,6 +94,20 @@
               <g id="comment-icon">
                 <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
               </g>
+            </svg>
+        </div>
+        <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+                 class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
+                <path d="M12 5v16" />
+                <path d="M7 7h1" />
+                <path d="M7 11h1" />
+                <path d="M16 7h1" />
+                <path d="M16 11h1" />
+                <path d="M16 15h1" />
             </svg>
         </div>
     </form>

--- a/glossary.html
+++ b/glossary.html
@@ -20,7 +20,6 @@
     <meta property="og:site_name" content="suttas.hillsidehermitage.org" />
     <meta property="og:image" itemprop="image" content="https://suttas.hillsidehermitage.org/images/favicon.jpg" />
     <script defer src="js/showdown.min.js"></script>
-    <script defer src="js/fuse.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/glossary.html
+++ b/glossary.html
@@ -6,7 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+        integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+        crossorigin="anonymous">
     <link rel="icon" type="image/jpeg" href="./images/favicon.jpg">
     <link rel="manifest" href="/manifest.json">
     <title>Hillside Hermitage Sutta Translations</title>
@@ -18,27 +20,27 @@
     <meta property="og:site_name" content="suttas.hillsidehermitage.org" />
     <meta property="og:image" itemprop="image" content="https://suttas.hillsidehermitage.org/images/favicon.jpg" />
     <script defer src="js/showdown.min.js"></script>
-    <script src="https://unpkg.com/dexie/dist/dexie.js"></script>
+    <script defer src="js/fuse.js"></script>
     <script>
-       if ('serviceWorker' in navigator) {
-		  window.addEventListener('load', () => {
-			navigator.serviceWorker.getRegistrations().then(registrations => {
-			  if (registrations.length === 0) {
-				// Service worker is not yet registered, so register it
-				navigator.serviceWorker.register('sw.js')
-				  .then(registration => {
-					console.log('[SUCCESS] Service Worker registered with scope:', registration.scope);
-				  })
-				  .catch(error => {
-					console.error('[ERROR] Service Worker registration failed:', error);
-				  });
-			  } else {
-				console.log('[INFO] Service Worker is already registered');
-			  }
-			});
-            
-		  });
-}
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.getRegistrations().then(registrations => {
+                    if (registrations.length === 0) {
+                        // Service worker is not yet registered, so register it
+                        navigator.serviceWorker.register('sw.js')
+                            .then(registration => {
+                                console.log('Service Worker registered with scope:', registration.scope);
+                            })
+                            .catch(error => {
+                                console.error('Service Worker registration failed:', error);
+                            });
+                    } else {
+                        console.log('Service Worker is already registered');
+                    }
+                });
+
+            });
+        }
     </script>
 </head>
 
@@ -66,21 +68,14 @@
                     fill="currentColor" />
             </svg>
         </div>
-        <input id="search-bar" type="text" placeholder="Search by citation, title or content">
-        <div id="home-button" class="icon-button">
+        <!-- <input id="citation" type="text" placeholder="Enter citation or search by title"> -->
+        <div id="home-button" class="icon-button" onclick="location.href='/'">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
                 <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
                     <path
                         d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
                         fill="currentColor" />
                 </g>
-            </svg>
-        </div>
-        <div id="theme-button" class="icon-button">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
             </svg>
         </div>
         <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'">
@@ -116,33 +111,10 @@
             </svg>
         </div>
     </form>
-    <div id="app-content">
-      <div id="whats-new"></div>
-      <div id="sutta">
-          <div style="display: flex; justify-content: center;"><span id="foreword-button" class="foreword-link">Foreword</span></div>
-      </div>
+    <div id="glossaryArea">
     </div>
-    <hr />
-    <div id="navigation" class="navigation">
-        <div id="previous"></div>
-        <div id="next"></div>
-    </div>
-    
-    <div id="footer">
-        <style>
-        .container {
-            display: flex;
-            flex-direction: column; /* Stack the elements vertically */
-            align-items: center; /* Center them horizontally */
-        }
-        </style>
-        <div class="container">
-            <button id="hardRefresh" class="box-button orange">Reset website</button>
-            <button id="reportButton" class="box-button red">Report an error</button>
-            <a style="margin: 5px" href="https://hillsidehermitage.org">Hillside Hermitage Website</a>
-        </div>
-    </div>
-    <script type="module" src="index.js"></script>
+    <!-- <script type="module" src="index.js"></script> -->
+    <script type="module" src="glossary.js"></script>
 </body>
 
 </html>

--- a/glossary.js
+++ b/glossary.js
@@ -1,0 +1,42 @@
+var converter = new showdown.Converter();
+
+function loadGlossary() {
+    fetch('glossary.json')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok ' + response.statusText);
+        }
+        return response.json();
+      })
+      .then(data => {
+        var converter = new showdown.Converter();
+        var glossaryDiv = document.getElementById('glossaryArea');
+        var glossary = data.glossary;
+        var output = '';
+  
+        // Get the glossary terms and sort them alphabetically
+          var terms = Object.keys(glossary).sort();
+    
+          // Iterate over the sorted terms
+          for (var i = 0; i < terms.length; i++) {
+            var term = terms[i];
+            var definitionMarkdown = glossary[term];
+            var definitionHtml = converter.makeHtml(definitionMarkdown);
+    
+            // Build the HTML output
+            output += '<div class="glossary-item">';
+            output += '<h2>' + term + '</h2>';
+            output += '<div class="definition">' + definitionHtml + '</div>';
+            output += '</div>';
+          }
+  
+        // Insert the HTML into the glossaryArea div
+        glossaryDiv.innerHTML = output;
+      })
+      .catch(error => {
+        console.error('Error loading glossary:', error);
+        document.getElementById('glossaryArea').innerText = 'Failed to load glossary.';
+      });
+  }
+
+  loadGlossary();

--- a/glossary.json
+++ b/glossary.json
@@ -1,0 +1,7 @@
+{
+    "glossary": {
+      "yoniso manasikāra": "insert definition here",
+      "sati": "literally means “memory” or “recollection”, from _√sar_ (“remember”), whereas “mindfulness” often has connotations of “focused awareness” that are foreign to the term _sati_. [MN 53](https://suttas.hillsidehermitage.org/?q=mn53) defines a noble disciple endowed with supreme _sati_ as “one who remembers what was said and done long ago”. <br><br>It is the same quality, just applied to one’s present experience, that is used in all the _satipaṭṭhānas_."
+    }
+  }
+  

--- a/index.css
+++ b/index.css
@@ -826,3 +826,12 @@ bookmarkButton{
 .orange {
   background-color: orange;
 }
+.glossary-item {
+  margin-bottom: 20px;
+}
+.glossary-item h2 {
+  margin-bottom: 10px;
+}
+.definition {
+  padding-left: 20px;
+}


### PR DESCRIPTION
Add basic glossary functionality.

Entries go in glossary.json. Markdown supported. At the moment the entries are sorted at render time in the js. At the later point it might be worth adding a github action to sort the file itself so one doesn't have to worry about where to add the entry.

At the moment all pages other than than the home page are being rendered in dark mode. My guess is that index.js errors out in other pages (perhaps due to the database change or it may have always been the case). I'm hoping to fix this with the settings panel update.