### PR TITLE
Fix issue with link to portion of text giving an error

### DIFF
--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -1,4 +1,4 @@
-import './highlightSegments.js';
+import { highlightSegments } from './highlightSegments.js';
 
 // This code enables highlighting of text segments in the sutta based on URL hash ranges.
 // For example, accessing the URL 127.0.0.1:8080/?q=mn1#mn1:23.1-mn1:194.6 will highlight the range from mn1:23.1 to mn1:194.6.


### PR DESCRIPTION
Fix issue that gives "not a valid citation" error when following a link to a portion of text e.g. https://suttas.hillsidehermitage.org/?q=mn1#mn1:2.2-mn1:2.3
Also fixes links to comment and links at the end of comment to paragraph linking to comment.

closes #196.

@bkhpanigha 