### PR TITLE
Fix issue with epub generation

### DIFF
--- a/.github/workflows/buildTestDeploy.yml
+++ b/.github/workflows/buildTestDeploy.yml
@@ -37,7 +37,16 @@ jobs:
       - name: Run suttas_database_data_generator.py script
         run: python python/scripts/suttas_database_data_generator.py
 
+      - name: Check if suttas-database-data.json changed
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep -q "^python/generated/suttas-database-data.json$"; then
+            echo "file_changed=true" >> $GITHUB_ENV
+          else
+            echo "file_changed=false" >> $GITHUB_ENV
+          fi
+
       - name: Run epub_book_generator.py script
+        if: env.file_changed == 'true'
         run: python python/scripts/epub_book_generator.py
         
       - name: Set up Git config


### PR DESCRIPTION
Right now the EPUB is generated everytime buildTestDeploy.yml runs, though nothing changes in the book, the compression process itself actually gives a different file everytime, just a few bytes of difference, but enough to push this "new" file on the main branch **everytime**.

This slight modification of buildTestDeploy.yml aims at checking if there are actual changes in the translations or comments by checking if there are changes in `python/generated/suttas-database-data.json` and only then generate a new EPUB.