### PR TITLE
abstract header bar and icons

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -44,75 +44,7 @@
 </head>
 
 <body id='appbody' class="hidden">
-    <div class="links-area">
-        <a href="https://github.com/bkhpanigha/hh-suttas" title="The source code for this site" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/GitHub-Mark-64px-black.png" alt="GitHub icon"></a>
-        <a href="https://www.youtube.com/channel/UCKejmWAt_kNpRMq5gQEGAqw" title="YouTube Channel" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/favicon-youtube.png" alt="Donate icon"></a>
-        <a href="https://www.hillsidehermitage.org/support-us/" title="Support Us" rel="noreferrer" target="_blank"><img
-                width="20px" src="./images/favicon-donate.png" alt="Donate icon"></a>
-        <div id="container">
-            <div id="buttonsContainer">
-                <button id="cacheButton" class="download-button">Use Offline</button>
-                <button id="infoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-	    <div id="epubButtonsContainer">
-                <button id="downloadEpubButton" class="download-button">Get Ebook</button>
-                <button id="epubInfoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-        </div>
-    </div>
-
-    <div id="top-buttons" class="button-container">
-        <div id="home-button" class="icon-button" title="Home">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
-                <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
-                    <path
-                        d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
-                        fill="currentColor" />
-                </g>
-            </svg>
-        </div>
-	<div id="theme-button" class="icon-button" title="Dark mode">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
-            </svg>
-        </div>
-        <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'" title="Bookmarks">
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor"
-                width="22" height="20" version="1.1" id="Layer_1" viewBox="0 0 463.273 463.273" xml:space="preserve">
-                <g>
-                    <g>
-                        <path
-                            d="M313.874,0H149.398c-16.28,0-29.477,13.197-29.476,29.477v422.368c0,4.532,2.679,8.637,6.827,10.461    c4.148,1.824,8.983,1.025,12.324-2.038l84.84-77.788c4.369-4.006,11.076-4.006,15.446,0l84.84,77.788    c3.34,3.063,8.175,3.863,12.324,2.038s6.827-5.929,6.827-10.461h0.001V29.477C343.351,13.197,330.154,0,313.874,0z" />
-                    </g>
-                </g>
-            </svg>
-        </div>
-        <div id="comments-button" class="icon-button" onclick="location.href='/comments.html'" title="Comments">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <g id="comment-icon">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
-              </g>
-            </svg>
-        </div>
-        <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'" title="Glossary">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
-                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
-                 class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
-                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
-                <path d="M12 5v16" />
-                <path d="M7 7h1" />
-                <path d="M7 11h1" />
-                <path d="M16 7h1" />
-                <path d="M16 11h1" />
-                <path d="M16 15h1" />
-            </svg>
-        </div>
-    </div>
+    <div id="header-placeholder"></div>
     <div id="bookmarksArea">
         <input type="text" placeholder="Enter new label" id="newLabelInput">
         <button id="createLabelButton">Create Label</button>
@@ -136,6 +68,7 @@
         </div>
     </div>
     <script type="module" src="index.js"></script>
+    <script src="js/utils/contentSections/loadHeader.js"></script>
     <script type="module" src="bookmarks.js"></script>
 </body>
 </html>

--- a/comments.html
+++ b/comments.html
@@ -44,75 +44,7 @@
 </head>
 
 <body id='appbody' class="hidden">
-    <div class="links-area">
-        <a href="https://github.com/bkhpanigha/hh-suttas" title="The source code for this site" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/GitHub-Mark-64px-black.png" alt="GitHub icon"></a>
-        <a href="https://www.youtube.com/channel/UCKejmWAt_kNpRMq5gQEGAqw" title="YouTube Channel" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/favicon-youtube.png" alt="Donate icon"></a>
-        <a href="https://www.hillsidehermitage.org/support-us/" title="Support Us" rel="noreferrer" target="_blank"><img
-                width="20px" src="./images/favicon-donate.png" alt="Donate icon"></a>
-        <div id="container">
-            <div id="buttonsContainer">
-                <button id="cacheButton" class="download-button">Use Offline</button>
-                <button id="infoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-	    <div id="epubButtonsContainer">
-                <button id="downloadEpubButton" class="download-button">Get Ebook</button>
-                <button id="epubInfoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-        </div>
-    </div>
-
-    <div id="top-buttons" class="button-container">
-        <div id="home-button" class="icon-button" title="Home">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
-                <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
-                    <path
-                        d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
-                        fill="currentColor" />
-                </g>
-            </svg>
-        </div>
-	<div id="theme-button" class="icon-button" title="Dark mode">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
-            </svg>
-        </div>
-        <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'" title="Bookmarks">
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor"
-                width="22" height="20" version="1.1" id="Layer_1" viewBox="0 0 463.273 463.273" xml:space="preserve">
-                <g>
-                    <g>
-                        <path
-                            d="M313.874,0H149.398c-16.28,0-29.477,13.197-29.476,29.477v422.368c0,4.532,2.679,8.637,6.827,10.461    c4.148,1.824,8.983,1.025,12.324-2.038l84.84-77.788c4.369-4.006,11.076-4.006,15.446,0l84.84,77.788    c3.34,3.063,8.175,3.863,12.324,2.038s6.827-5.929,6.827-10.461h0.001V29.477C343.351,13.197,330.154,0,313.874,0z" />
-                    </g>
-                </g>
-            </svg>
-        </div>
-        <div id="comments-button" class="icon-button" onclick="location.href='/comments.html'" title="Comments">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <g id="comment-icon">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
-              </g>
-            </svg>
-        </div>
-        <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'" title="Glossary">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
-                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
-                 class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
-                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
-                <path d="M12 5v16" />
-                <path d="M7 7h1" />
-                <path d="M7 11h1" />
-                <path d="M16 7h1" />
-                <path d="M16 11h1" />
-                <path d="M16 15h1" />
-            </svg>
-        </div>
-    </div>
+    <div id="header-placeholder"></div>
     <div id="progressContainer">
         <p id="loadingText">Loading comments...</p>
         <progress id="progressBar" value="0" max="100"></progress>
@@ -128,6 +60,7 @@
         </div>
     </div>
     <script type="module" src="index.js"></script>
+    <script src="js/utils/contentSections/loadHeader.js"></script>
     <script type="module" src="comments.js"></script>
 </body>
 </html>

--- a/glossary.html
+++ b/glossary.html
@@ -44,75 +44,7 @@
 </head>
 
 <body id='appbody' class="hidden">
-    <div class="links-area">
-        <a href="https://github.com/bkhpanigha/hh-suttas" title="The source code for this site" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/GitHub-Mark-64px-black.png" alt="GitHub icon"></a>
-        <a href="https://www.youtube.com/channel/UCKejmWAt_kNpRMq5gQEGAqw" title="YouTube Channel" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/favicon-youtube.png" alt="Donate icon"></a>
-        <a href="https://www.hillsidehermitage.org/support-us/" title="Support Us" rel="noreferrer" target="_blank"><img
-                width="20px" src="./images/favicon-donate.png" alt="Donate icon"></a>
-        <div id="container">
-            <div id="buttonsContainer">
-                <button id="cacheButton" class="download-button">Use Offline</button>
-                <button id="infoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-	    <div id="epubButtonsContainer">
-                <button id="downloadEpubButton" class="download-button">Get Ebook</button>
-                <button id="epubInfoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-        </div>
-    </div>
-
-    <div id="top-buttons" class="button-container">
-        <div id="home-button" class="icon-button" title="Home">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
-                <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
-                    <path
-                        d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
-                        fill="currentColor" />
-                </g>
-            </svg>
-        </div>
-	<div id="theme-button" class="icon-button" title="Dark mode">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
-            </svg>
-        </div>
-        <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'" title="Bookmarks">
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor"
-                width="22" height="20" version="1.1" id="Layer_1" viewBox="0 0 463.273 463.273" xml:space="preserve">
-                <g>
-                    <g>
-                        <path
-                            d="M313.874,0H149.398c-16.28,0-29.477,13.197-29.476,29.477v422.368c0,4.532,2.679,8.637,6.827,10.461    c4.148,1.824,8.983,1.025,12.324-2.038l84.84-77.788c4.369-4.006,11.076-4.006,15.446,0l84.84,77.788    c3.34,3.063,8.175,3.863,12.324,2.038s6.827-5.929,6.827-10.461h0.001V29.477C343.351,13.197,330.154,0,313.874,0z" />
-                    </g>
-                </g>
-            </svg>
-        </div>
-        <div id="comments-button" class="icon-button" onclick="location.href='/comments.html'" title="Comments">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <g id="comment-icon">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
-              </g>
-            </svg>
-        </div>
-        <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'" title="Glossary">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
-                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
-                 class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
-                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
-                <path d="M12 5v16" />
-                <path d="M7 7h1" />
-                <path d="M7 11h1" />
-                <path d="M16 7h1" />
-                <path d="M16 11h1" />
-                <path d="M16 15h1" />
-            </svg>
-        </div>
-    </div>
+    <div id="header-placeholder"></div>
     <div id="glossaryArea">
     </div>
     <hr />
@@ -124,6 +56,7 @@
         </div>
     </div>
     <script type="module" src="index.js"></script>
+    <script src="js/utils/contentSections/loadHeader.js"></script>
     <script type="module" src="glossary.js"></script>
 </body>
 </html>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,69 @@
+<div class="links-area">
+    <a href="https://github.com/bkhpanigha/hh-suttas" title="The source code for this site" rel="noreferrer"
+        target="_blank"><img width="20px" src="./images/GitHub-Mark-64px-black.png" alt="GitHub icon"></a>
+    <a href="https://www.youtube.com/channel/UCKejmWAt_kNpRMq5gQEGAqw" title="YouTube Channel" rel="noreferrer"
+        target="_blank"><img width="20px" src="./images/favicon-youtube.png" alt="Donate icon"></a>
+    <a href="https://www.hillsidehermitage.org/support-us/" title="Support Us" rel="noreferrer" target="_blank"><img
+            width="20px" src="./images/favicon-donate.png" alt="Donate icon"></a>
+    <div id="container">
+        <div id="buttonsContainer">
+            <button id="cacheButton" class="download-button">Use Offline</button>
+            <button id="infoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
+        </div>
+    <div id="epubButtonsContainer">
+            <button id="downloadEpubButton" class="download-button">Get Ebook</button>
+            <button id="epubInfoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
+        </div>
+    </div>
+</div>
+
+<div id="top-buttons" class="button-container">
+    <div id="home-button" class="icon-button" title="Home">
+        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
+            <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
+                <path
+                    d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
+                    fill="currentColor" />
+            </g>
+        </svg>
+    </div>
+<div id="theme-button" class="icon-button" title="Dark mode">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
+            <path
+                d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
+                fill="currentColor" />
+        </svg>
+    </div>
+    <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'" title="Bookmarks">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor"
+            width="22" height="20" version="1.1" id="Layer_1" viewBox="0 0 463.273 463.273" xml:space="preserve">
+            <g>
+                <g>
+                    <path
+                        d="M313.874,0H149.398c-16.28,0-29.477,13.197-29.476,29.477v422.368c0,4.532,2.679,8.637,6.827,10.461    c4.148,1.824,8.983,1.025,12.324-2.038l84.84-77.788c4.369-4.006,11.076-4.006,15.446,0l84.84,77.788    c3.34,3.063,8.175,3.863,12.324,2.038s6.827-5.929,6.827-10.461h0.001V29.477C343.351,13.197,330.154,0,313.874,0z" />
+                </g>
+            </g>
+        </svg>
+    </div>
+    <div id="comments-button" class="icon-button" onclick="location.href='/comments.html'" title="Comments">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <g id="comment-icon">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
+          </g>
+        </svg>
+    </div>
+    <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'" title="Glossary">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+             class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
+            <path d="M12 5v16" />
+            <path d="M7 7h1" />
+            <path d="M7 11h1" />
+            <path d="M16 7h1" />
+            <path d="M16 11h1" />
+            <path d="M16 15h1" />
+        </svg>
+    </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -42,75 +42,7 @@
 </head>
 
 <body id='appbody' class="hidden">
-    <div class="links-area">
-        <a href="https://github.com/bkhpanigha/hh-suttas" title="The source code for this site" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/GitHub-Mark-64px-black.png" alt="GitHub icon"></a>
-        <a href="https://www.youtube.com/channel/UCKejmWAt_kNpRMq5gQEGAqw" title="YouTube Channel" rel="noreferrer"
-            target="_blank"><img width="20px" src="./images/favicon-youtube.png" alt="Donate icon"></a>
-        <a href="https://www.hillsidehermitage.org/support-us/" title="Support Us" rel="noreferrer" target="_blank"><img
-                width="20px" src="./images/favicon-donate.png" alt="Donate icon"></a>
-        <div id="container">
-            <div id="buttonsContainer">
-                <button id="cacheButton" class="download-button">Use Offline</button>
-                <button id="infoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-	    <div id="epubButtonsContainer">
-                <button id="downloadEpubButton" class="download-button">Get Ebook</button>
-                <button id="epubInfoButton" class="info-btn"><img src="images/info-empty.256x256.png" alt="Info"></button>
-            </div>
-        </div>
-    </div>
-
-    <div id="top-buttons" class="button-container">
-        <div id="home-button" class="icon-button" title="Home">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" viewBox="2.5 0 15 15">
-                <g transform="matrix(0.13384491 0 0 0.13384491 1.7765683 -0)">
-                    <path
-                        d="M61.44 0L0 60.18L14.99 68.05L61.04 19.7L107.89 68.06L122.88 60.19L61.44 0zM18.26 69.63L61.5 26.38L104.61 69.63L104.61 112.06L73.12 112.06L73.12 82.09L49.49 82.09L49.49 112.06L18.26 112.06L18.26 69.63z"
-                        fill="currentColor" />
-                </g>
-            </svg>
-        </div>
-	<div id="theme-button" class="icon-button" title="Dark mode">
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
-                <path
-                    d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12-5.373-12-12-12-12 5.373-12 12zm2 0c0-5.514 4.486-10 10-10v20c-5.514 0-10-4.486-10-10z"
-                    fill="currentColor" />
-            </svg>
-        </div>
-        <div id="bookmarks-button" class="icon-button" onclick="location.href='/bookmarks.html'" title="Bookmarks">
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor"
-                width="22" height="20" version="1.1" id="Layer_1" viewBox="0 0 463.273 463.273" xml:space="preserve">
-                <g>
-                    <g>
-                        <path
-                            d="M313.874,0H149.398c-16.28,0-29.477,13.197-29.476,29.477v422.368c0,4.532,2.679,8.637,6.827,10.461    c4.148,1.824,8.983,1.025,12.324-2.038l84.84-77.788c4.369-4.006,11.076-4.006,15.446,0l84.84,77.788    c3.34,3.063,8.175,3.863,12.324,2.038s6.827-5.929,6.827-10.461h0.001V29.477C343.351,13.197,330.154,0,313.874,0z" />
-                    </g>
-                </g>
-            </svg>
-        </div>
-        <div id="comments-button" class="icon-button" onclick="location.href='/comments.html'" title="Comments">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <g id="comment-icon">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="currentColor"/></path>
-              </g>
-            </svg>
-        </div>
-        <div id="glossary-button" class="icon-button" onclick="location.href='/glossary.html'" title="Glossary">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" 
-                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
-                 class="icon icon-tabler icons-tabler-outline icon-tabler-vocabulary">
-                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                <path d="M10 19h-6a1 1 0 0 1 -1 -1v-14a1 1 0 0 1 1 -1h6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2h6a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-6a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2z" />
-                <path d="M12 5v16" />
-                <path d="M7 7h1" />
-                <path d="M7 11h1" />
-                <path d="M16 7h1" />
-                <path d="M16 11h1" />
-                <path d="M16 15h1" />
-            </svg>
-        </div>
-    </div>
+    <div id="header-placeholder"></div>
     <form id="form">
         <div class="search-icon">
             <svg width="13" height="13" viewBox="3 3 18 18">
@@ -139,6 +71,7 @@
             <a style="margin: 5px" href="https://hillsidehermitage.org">Hillside Hermitage Website</a>
         </div>
     </div>
+    <script src="js/utils/contentSections/loadHeader.js"></script>
     <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/js/utils/contentSections/loadHeader.js
+++ b/js/utils/contentSections/loadHeader.js
@@ -1,0 +1,18 @@
+// loadHeader.js
+
+// Check if the browser supports the Fetch API
+    // Fetch the content of header.html
+fetch('/header.html')
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        return response.text();
+    })
+    .then(data => {
+        // Insert the fetched content into the placeholder
+        document.getElementById('header-placeholder').innerHTML = data;
+    })
+    .catch(error => {
+        console.error('Error fetching header:', error);
+    });


### PR DESCRIPTION
One thing to note for those using `live-server` as their local http server, it seems to only show the first 3 icons because it injects something for the auto-reload I'm told. So a way around it would be to use a python http server with the following command:
```
python -m http.server 8080
```