### PR TITLE
Fix passage link with compound verse issue

### DIFF
--- a/js/utils/misc/generateLink.js
+++ b/js/utils/misc/generateLink.js
@@ -16,7 +16,7 @@ export function generateLink(idOrRange) {
     if (typeof idOrRange === "string") {
       hash += idOrRange;
     } else if (Array.isArray(idOrRange) && idOrRange.length === 2) {
-      hash += `${idOrRange[0]}-${idOrRange[1]}`;
+      hash += `${idOrRange[0]}_${idOrRange[1]}`;
     } else {
       console.error("Invalid ID or Range format");
       return "";

--- a/js/utils/navigation/highlightSegments.js
+++ b/js/utils/navigation/highlightSegments.js
@@ -1,5 +1,54 @@
-export function highlightSegments(startElement, endElement = null, quickHighlight = false) 
-{
+// Helper function to parse segment IDs into comparable parts
+function parseSegmentId(id) {
+    // Format expected: mnXX:YY.Z or mnXX:YY-ZZ.W
+    const match = id.match(/^mn(\d+):(\d+)(?:-(\d+))?\.(\d+)$/);
+    if (!match) return null;
+    
+    const [_, sutra, startVerse, endVerse, subVerse] = match;
+    return {
+        sutra: parseInt(sutra),
+        startVerse: parseInt(startVerse),
+        endVerse: endVerse ? parseInt(endVerse) : parseInt(startVerse),
+        subVerse: parseInt(subVerse)
+    };
+}
+
+// Helper function to compare two segment positions
+function compareSegmentPositions(id1, id2) {
+    const pos1 = parseSegmentId(id1);
+    const pos2 = parseSegmentId(id2);
+    
+    if (!pos1 || !pos2) return 0;
+    
+    // Compare sutra numbers
+    if (pos1.sutra !== pos2.sutra) {
+        return pos1.sutra - pos2.sutra;
+    }
+    
+    // Compare verses
+    if (pos1.startVerse !== pos2.startVerse) {
+        return pos1.startVerse - pos2.startVerse;
+    }
+    
+    // If one has an endVerse and the other doesn't, compare appropriately
+    if (pos1.endVerse !== pos2.endVerse) {
+        return pos1.endVerse - pos2.endVerse;
+    }
+    
+    // Compare subverses
+    return pos1.subVerse - pos2.subVerse;
+}
+
+// Helper function to check if a segment is within range
+function isSegmentInRange(currentId, startId, endId) {
+    const compareStart = compareSegmentPositions(currentId, startId);
+    const compareEnd = compareSegmentPositions(currentId, endId);
+    
+    // If current segment is equal to or after start, and equal to or before end
+    return compareStart >= 0 && compareEnd <= 0;
+}
+
+export function highlightSegments(startElement, endElement = null, quickHighlight = false) {
     // Remove all previous highlights
     document.querySelectorAll('.highlight').forEach(element => {
         element.classList.remove('highlight');
@@ -8,42 +57,33 @@ export function highlightSegments(startElement, endElement = null, quickHighligh
     // If it's the single element case (endElement is null), directly highlight it
     if (startElement && !endElement) {
         startElement.classList.add("highlight");
-
+        
         if (quickHighlight) {
-        setTimeout(() => {
-            startElement.classList.remove('highlight'); // Remove highlight after transition
-        }, 2000); // Adjust the quick highlight duration (in ms) as needed
+            setTimeout(() => {
+                startElement.classList.remove('highlight');
+            }, 2000);
         }
-        return; // No need to loop or do anything else for the single element case
+        return;
     }
 
     // If there's a startElement and an endElement (range case)
     if (startElement && endElement) {
-        let highlight = false;
+        const startId = startElement.id;
+        const endId = endElement.id;
         const segments = document.getElementsByClassName("segment");
 
         for (const segment of segments) {
-        if (segment.id === startElement.id) {
-            highlight = true;
+            if (isSegmentInRange(segment.id, startId, endId)) {
+                segment.classList.add("highlight");
+            }
         }
 
-        if (highlight) {
-            segment.classList.add("highlight");
-        }
-
-        // Stop highlighting when we reach the end element
-        if (segment.id === endElement.id) {
-            break;
-        }
-        }
-
-        // If quick highlight is enabled, smoothly de-highlight after a short duration
         if (quickHighlight) {
-        setTimeout(() => {
-            document.querySelectorAll('.highlight').forEach(element => {
-            element.classList.remove('highlight'); // Let the transition handle smooth de-highlight
-            });
-        }, 2000); // Adjust the quick highlight duration (in ms) as needed
+            setTimeout(() => {
+                document.querySelectorAll('.highlight').forEach(element => {
+                    element.classList.remove('highlight');
+                });
+            }, 2000);
         }
     }
 }

--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -1,52 +1,84 @@
 import { highlightSegments } from './highlightSegments.js';
 
 // This code enables highlighting of text segments in the sutta based on URL hash ranges.
-// For example, accessing the URL 127.0.0.1:8080/?q=mn1#mn1:23.1-mn1:194.6 will highlight the range from mn1:23.1 to mn1:194.6.
-// Similarly, accessing 127.0.0.1:8080/?q=mn1#mn1:23.1 will highlight the single segment at mn1:23.1.
-// it also handles cases where there is a need for quick highlighting and no highlighting
-// 127.0.0.1:8080/?q=mn1#mn1:23.1-mn1:194.6~quick-highlight and 127.0.0.1:8080/?q=mn1#mn1:23.1-mn1:194.6~no-highlight
+// Examples:
+// - Single verse: 127.0.0.1:8080/?q=mn1#mn1:23.1
+// - Verse range: 127.0.0.1:8080/?q=mn1#mn1:23.1-mn1:194.6
+// - Compound verse: 127.0.0.1:8080/?q=mn28#mn28:29-30.1
+// - Compound verse range: 127.0.0.1:8080/?q=mn28#mn28:29-30.1-mn28:37.1
+// Options:
+// - Quick highlight: append ~quick-highlight
+// - No highlight: append ~no-highlight
+
+function parseVerseId(verseId) {
+    // Match patterns like:
+    // mn28:29.1
+    // mn28:29-30.1
+    const basicPattern = /^(mn\d+):(\d+(?:-\d+)?\.(?:\d+))$/;
+    const match = verseId.match(basicPattern);
+    
+    if (!match) return null;
+    return match[1] + ':' + match[2];
+}
+
 export function scrollToHash() {
     const fullHash = window.location.hash.substring(1); // Remove the '#' from the hash
-  
+    
     // Split on `~` to separate the hash part from any options
     const [hash, options] = fullHash.split('~');
-  
+    
     // Check for the quick-highlight or no-highlight options in the URL
     const isQuickHighlight = options && options.includes('quick-highlight');
     const isNoHighlight = options && options.includes('no-highlight');
-  
+    
     if (hash.startsWith('comment')) {
-      const commentElement = document.getElementById(hash);
-      if (commentElement) {
-        commentElement.classList.add("comment-highlight");
-        commentElement.scrollIntoView();
-      }
-    } else if (hash) {
-      // Try matching the range pattern
-      const rangeMatch = hash.match(/(.*?):(\d+\.\d+\.\d+|\d+\.\d+)-(.*?):(\d+\.\d+\.\d+|\d+\.\d+)/);
-      if (rangeMatch) {
-        const [, startIdPrefix, startIdSuffix, endIdPrefix, endIdSuffix] = rangeMatch;
-        const startFullId = `${startIdPrefix}:${startIdSuffix}`;
-        const endFullId = `${endIdPrefix}:${endIdSuffix}`;
-        const startElement = document.getElementById(startFullId);
-        const endElement = document.getElementById(endFullId);
-  
-        if (startElement && endElement) {
-          // If no-highlight is present, skip highlighting
-          if (!isNoHighlight) {
-            highlightSegments(startElement, endElement, isQuickHighlight);
-          }
-          startElement.scrollIntoView();
+        const commentElement = document.getElementById(hash);
+        if (commentElement) {
+            commentElement.classList.add("comment-highlight");
+            commentElement.scrollIntoView();
         }
-      } else {
-        // Handle single element case using the same highlightSegments function
-        const targetElement = document.getElementById(hash);
-        if (targetElement) {
-          if (!isNoHighlight) {
-            highlightSegments(targetElement, null, isQuickHighlight); // Treat single element case
-          }
-          targetElement.scrollIntoView(); // Directly scroll to the single target element
-        }
-      }
+        return;
     }
-  }
+    
+    if (!hash) return;
+    
+    // Try matching the range pattern first
+    // This will match patterns like:
+    // mn1:23.1-mn1:194.6
+    // mn28:29-30.1-mn28:37.1
+    const rangePattern = /^(.+?)-(.+?)$/;
+    const rangeMatch = hash.match(rangePattern);
+    
+    if (rangeMatch) {
+        // We have a range
+        const [, startId, endId] = rangeMatch;
+        
+        // Parse both IDs
+        const parsedStartId = parseVerseId(startId);
+        const parsedEndId = parseVerseId(endId);
+        
+        if (parsedStartId && parsedEndId) {
+            const startElement = document.getElementById(parsedStartId);
+            const endElement = document.getElementById(parsedEndId);
+            
+            if (startElement && endElement) {
+                if (!isNoHighlight) {
+                    highlightSegments(startElement, endElement, isQuickHighlight);
+                }
+                startElement.scrollIntoView();
+            }
+        }
+    } else {
+        // Handle single element case
+        const parsedId = parseVerseId(hash);
+        if (parsedId) {
+            const targetElement = document.getElementById(parsedId);
+            if (targetElement) {
+                if (!isNoHighlight) {
+                    highlightSegments(targetElement, null, isQuickHighlight);
+                }
+                targetElement.scrollIntoView();
+            }
+        }
+    }
+}

--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -17,43 +17,22 @@ export function scrollToHash() {
             commentElement.scrollIntoView();
         }
     } else if (hash) {
-        // Enhanced regex pattern to match both normal and composite IDs
-        // Examples it will match:
-        // - mn1:1.2_mn1:1.5
-        // - mn28:29-30.1_mn28:37.1
-        // - mn28:28.9_mn28:31-32.1
-        const rangeMatch = hash.match(
-            /(.*?):(\d+(?:-\d+)?(?:\.\d+)?)(?:_(.*?):(\d+(?:-\d+)?(?:\.\d+)?))?/
-        );
-
-        if (rangeMatch) {
-            const [, startIdPrefix, startIdSuffix, endIdPrefix, endIdSuffix] = rangeMatch;
-            const startFullId = `${startIdPrefix}:${startIdSuffix}`;
+        // Check if it's a range (contains underscore)
+        const isRange = hash.includes('_');
+        
+        if (isRange) {
+            const [startId, endId] = hash.split('_');
+            const startElement = document.getElementById(startId);
+            const endElement = document.getElementById(endId);
             
-            // If there's no end range (single element case), use the start ID for both
-            const endFullId = endIdPrefix ? 
-                `${endIdPrefix}:${endIdSuffix}` : 
-                startFullId;
-            
-            const startElement = document.getElementById(startFullId);
-            const endElement = endIdPrefix ? 
-                document.getElementById(endFullId) : 
-                startElement;
-
             if (startElement) {
-                // If no-highlight is present, skip highlighting
                 if (!isNoHighlight) {
-                    // If there's no end range, pass null as endElement for single element case
-                    highlightSegments(
-                        startElement, 
-                        endIdPrefix ? endElement : null, 
-                        isQuickHighlight
-                    );
+                    highlightSegments(startElement, endElement, isQuickHighlight);
                 }
                 startElement.scrollIntoView();
             }
         } else {
-            // Handle single element case for both normal and composite IDs
+            // Handle single element case
             const targetElement = document.getElementById(hash);
             if (targetElement) {
                 if (!isNoHighlight) {

--- a/js/utils/navigation/showCopyButton.js
+++ b/js/utils/navigation/showCopyButton.js
@@ -23,7 +23,7 @@ export function showCopyButton(x, y, ids) {
       if (ids.length > 1) {
         const firstId = ids[0];
         const lastId = ids[ids.length - 1];
-        link = generateLink([firstId, lastId].join('-'));
+        link = generateLink([firstId, lastId].join('_'));
       } else if (ids.length === 1) {
         link = generateLink(ids[0]);
       }


### PR DESCRIPTION
Modify verse range separator from "-" to "_" in the url hash, so as to make processing the compound ids using "-" easier.

Handles ids like:
- an1.1:1.1
- an1.10:1.1
- an1.1-20:1.1
- mn28:29-30.1
- thag2.36:2.4
- snp4.2:4.1