### PR TITLE
Fix Advanced-Search max words displayed on mobile

### DIFF
--- a/js/utils/contentSections/SuttaSearch.js
+++ b/js/utils/contentSections/SuttaSearch.js
@@ -5,7 +5,7 @@ import { normalizeSpaces } from '../misc/normalizeSpaces.js';
 
 // Main search class for better data organization and caching
 class SuttaSearch {
-    constructor(textData, pali = false, maxWords) {
+    constructor(textData, pali = false) {
         this.originalText = textData;
         this.pali = pali;
         this.verseKeys = Object.keys(textData);
@@ -472,7 +472,7 @@ export const searchSutta = async (textData, searchTerm, isComment = false, stric
         return [];
     }
     
-    const searcher = new SuttaSearch(textData, pali, maxWords);
+    const searcher = new SuttaSearch(textData, pali);
     return await searcher.findMatches(searchTerm, strict, isComment, singleResult, maxWords, resultCallback);
 };
 

--- a/js/utils/contentSections/SuttaSearch.js
+++ b/js/utils/contentSections/SuttaSearch.js
@@ -2,11 +2,10 @@ import { removeDiacritics } from '../misc/removeDiacritics.js';
 import { cleanVerse } from '../misc/cleanVerse.js';
 import { escapeRegExp } from '../misc/escapeRegExp.js';
 import { normalizeSpaces } from '../misc/normalizeSpaces.js';
-import { getSearchLimits } from '../misc/advancedSearchConfig.js';
 
 // Main search class for better data organization and caching
 class SuttaSearch {
-    constructor(textData, pali = false) {
+    constructor(textData, pali = false, maxWords) {
         this.originalText = textData;
         this.pali = pali;
         this.verseKeys = Object.keys(textData);
@@ -16,9 +15,6 @@ class SuttaSearch {
         this.commentNumbers = new Map();
         this.positionMap = new Map();
         this.cleanedVerses = new Map();
-		const { maxWordsEn, maxWordsPl } = getSearchLimits();
-		this.maxWordsEn = maxWordsEn;
-        this.maxWordsPl = maxWordsPl;
         this.initialize();
     }
 
@@ -277,9 +273,7 @@ class SuttaSearch {
 		}
 	}
 
-	async findMatches(searchTerm, strict = false, isComment = false, singleResult = false, resultCallback) {
-		const maxWords = (this.pali ? 100 : 150);
-		
+	async findMatches(searchTerm, strict = false, isComment = false, singleResult = false, maxWords, resultCallback) {
 		// Create search term variations
 		let searchTerms = new Set();
 		
@@ -473,13 +467,13 @@ class SuttaSearch {
 }
 
 // Main search function
-export const searchSutta = async (textData, searchTerm, isComment = false, strict = false, pali = false, singleResult = false, resultCallback) => {
+export const searchSutta = async (textData, searchTerm, isComment = false, strict = false, pali = false, singleResult = false, maxWords, resultCallback) => {
     if (!textData || !searchTerm || typeof searchTerm !== 'string') {
         return [];
     }
     
-    const searcher = new SuttaSearch(textData, pali);
-    return await searcher.findMatches(searchTerm, strict, isComment, singleResult, resultCallback);
+    const searcher = new SuttaSearch(textData, pali, maxWords);
+    return await searcher.findMatches(searchTerm, strict, isComment, singleResult, maxWords, resultCallback);
 };
 
 export default searchSutta;

--- a/js/utils/contentSections/searchSuttasWithStop.js
+++ b/js/utils/contentSections/searchSuttasWithStop.js
@@ -91,7 +91,8 @@ export async function searchSuttasWithStop(searchTerm, options) {
                     options['strict'],
                     false,
                     options['single'],
-                    async (result) => processResult(result, sutta, id, finalDisplayTitle)
+					maxWordsEn,
+                    async (result) => processResult(result, sutta, id, finalDisplayTitle),
                 );
 
                 // Search in comments with progressive display
@@ -103,7 +104,8 @@ export async function searchSuttasWithStop(searchTerm, options) {
                         options['strict'],
                         false,
                         options['single'],
-                        async (result) => processResult(result, sutta, id, finalDisplayTitle, true)
+						maxWordsEn,
+                        async (result) => processResult(result, sutta, id, finalDisplayTitle, true),
                     );
                     updateProgress();
                 }
@@ -124,7 +126,8 @@ export async function searchSuttasWithStop(searchTerm, options) {
                     options['strict'],
                     true,
                     options['single'],
-                    async (result) => processResult(result, sutta, id, finalDisplayTitle)
+					maxWordsPl,
+                    async (result) => processResult(result, sutta, id, finalDisplayTitle),
                 );
 
                 // Handle title match without content match


### PR DESCRIPTION
Right now the max words a passage can have on mobile isn't changed (100 pl/150 en).
Make it work as intended (50 pl/75 en).
Also optimize the logic for getting maxWords, from calling it for every passage, to only once per search.