### PR TITLE
Fix new github action failing

### DIFF
--- a/.github/workflows/scheduledTasks.yml
+++ b/.github/workflows/scheduledTasks.yml
@@ -31,11 +31,10 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git pull --rebase origin ${{ github.ref }}  # Pull latest changes
-        git add python/generated/available_videos.json
-        if git diff --cached --quiet; then
-          echo "No changes to commit."
-        else
+        if ! git diff --exit-code python/generated/available_videos.json; then
+          git add python/generated/available_videos.json
           git commit -m "Update Available Videos Data"
-          git push origin HEAD:${{ github.ref }}
+          git push
+        else
+          echo "No changes to commit."
         fi


### PR DESCRIPTION
Simplify the code to only add ```python/generated/available_videos.json``` if it was changed by ```python/scripts/fetch_videos_data.py```.

For an unknown reason, the first time it launches it will replace the whole file's content, but subsequent launches will only add the missing new videos.