### PR TITLE
Adv. search improvements

### DIFF
--- a/advanced-search.css
+++ b/advanced-search.css
@@ -162,6 +162,7 @@ h3 {
 	width: 100%;
 	border-left: 3px solid transparent;
 	transition: background-color 0.2s;
+	position: relative;
 }
 
 .result[data-type="en"] {
@@ -180,7 +181,7 @@ h3 {
 	background-color: #f8fafc;
 }
 
-.result h3 > span {
+.result h3::before {
 	text-transform: lowercase;
 	font-size: 0.7rem;
 	letter-spacing: 0.05em;
@@ -191,6 +192,21 @@ h3 {
 	border: 1px solid #95a3b8;
 	padding: .05rem .4rem;
 	border-radius: 1rem;
+	position: absolute;
+	top: .75rem;
+	right: .75rem;
+}
+
+.result[data-type="en"] h3::before{
+	content: "english";
+}
+
+.result[data-type="pli"] h3::before{
+	content: "pāli";
+}
+
+.result[data-type="com"] h3::before{
+	content: "comment";
 }
 
 .result.placeholder {

--- a/advanced-search.css
+++ b/advanced-search.css
@@ -11,44 +11,45 @@ body {
 	color: var(--charcoal);
 }
 
-p{
+p {
 	margin-bottom: initial;
 }
 
-h2, h3{
+h2,
+h3 {
 	color: var(--black);
 }
 
-.links-area{
+.links-area {
 	margin: 0 3rem;
 }
 
-#panelsContainer{
+#panelsContainer {
 	display: flex;
 	flex-direction: column;
 	min-height: 90vh;
 	padding: 0px 4px;
 }
 
-#searchContainer{
+#searchContainer {
 	display: flex;
 }
 
-.dark #optionPanel{
+.dark #optionPanel {
 	background-color: var(--dark-brown);
 }
 
-#optionPanel h2{
-    font-size: 1.1rem;
-    margin-bottom: 0.5rem;
+#optionPanel h2 {
+	font-size: 1.1rem;
+	margin-bottom: 0.5rem;
 }
 
-#optionPanel h3{
+#optionPanel h3 {
 	font-size: 0.9rem;
-    margin-bottom: 0.25rem;
+	margin-bottom: 0.25rem;
 }
 
-#configuration{
+#configuration {
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
@@ -59,38 +60,38 @@ h2, h3{
 	cursor: pointer;
 }
 
-.search-field{
+.search-field {
 	margin-bottom: 0.5rem;
 }
 
-.search-field input{
-	width: 100%; 
-	padding: .5rem; 
-	font-size: .9em; 
-	border: 1px solid var(--lighter-gray); 
+.search-field input {
+	width: 100%;
+	padding: .5rem;
+	font-size: .9em;
+	border: 1px solid var(--lighter-gray);
 	border-radius: 5px;
 }
 
-.options{
+.options {
 	margin-bottom: 0;
-    padding: 0.5rem;
-    border-radius: 4px;
-    background: rgba(0, 0, 0, 0.03);
+	padding: 0.5rem;
+	border-radius: 4px;
+	background: rgba(0, 0, 0, 0.05);
 }
 
 .dark .options {
-    background: rgba(255, 255, 255, 0.03);
+	background: rgba(255, 255, 255, 0.05);
 }
 
 .dark .search-field,
-.dark .options{
+.dark .options {
 	color: var(--off-white);
 }
 
 .options-group {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.5rem;
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 0.5rem;
 }
 
 .options label {
@@ -98,14 +99,14 @@ h2, h3{
 	flex-direction: row;
 	gap: .3rem;
 	font-size: 0.85rem;
-    padding: 0.25rem 0;
-    margin: 0;
+	padding: 0.25rem 0;
+	margin: 0;
 }
 
 .switch-options {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.5rem;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	gap: 0.5rem;
 }
 
 .search-btn {
@@ -120,15 +121,15 @@ h2, h3{
 	border-radius: 5px;
 }
 
-.search-btn.red{
+.search-btn.red {
 	background-color: var(--red);
 }
 
-.dark .search-btn{
+.dark .search-btn {
 	border: 2px solid #BBB;
 }
 
-.search-btn:disabled{
+.search-btn:disabled {
 	background-color: #AAA;
 	cursor: not-allowed;
 }
@@ -137,7 +138,7 @@ h2, h3{
 	background-color: var(--darker-brown);
 }
 
-.search-btn.red:enabled:hover{
+.search-btn.red:enabled:hover {
 	background-color: var(--darker-red);
 }
 
@@ -159,12 +160,44 @@ h2, h3{
 	border-radius: 5px;
 	background-color: var(--white);
 	width: 100%;
+	border-left: 3px solid transparent;
+	transition: background-color 0.2s;
 }
 
-.result.placeholder{
+.result[data-type="en"] {
+	border-left-color: var(--blue);
+}
+
+.result[data-type="pli"] {
+	border-left-color: var(--orange-yellow);
+}
+
+.result[data-type="com"] {
+	border-left-color: var(--orange);
+}
+
+.result:hover {
+	background-color: #f8fafc;
+}
+
+.result h3 > span {
+	text-transform: lowercase;
+	font-size: 0.7rem;
+	letter-spacing: 0.05em;
+	color: #94a3b8;
+	margin-left: .5rem;
+	display: inline-block;
+	font-weight: normal;
+	border: 1px solid #95a3b8;
+	padding: .05rem .4rem;
+	border-radius: 1rem;
+}
+
+.result.placeholder {
 	padding: 20px;
 }
-.result.placeholder h1{
+
+.result.placeholder h1 {
 	font-size: 1.2rem;
 }
 
@@ -172,7 +205,7 @@ h2, h3{
 	background-color: var(--dark-brown);
 }
 
-.result > .link{
+.result>.link {
 	text-decoration: none;
 }
 
@@ -187,7 +220,7 @@ h2, h3{
 	line-height: 1.5;
 }
 
-.dark .result p{
+.dark .result p {
 	color: var(--off-white);
 }
 
@@ -197,11 +230,11 @@ b {
 	color: var(--light-orange);
 }
 
-b.dark{
+b.dark {
 	color: var(--dark-orange);
 }
 
-.dark b.dark{
+.dark b.dark {
 	color: var(--light-orange);
 }
 
@@ -212,7 +245,7 @@ b.dark{
 	background-color: var(--light-off-white);
 }
 
-.dark .loading-bar-container{
+.dark .loading-bar-container {
 	background-color: var(--darker-gray);
 }
 
@@ -236,9 +269,9 @@ b.dark{
 	height: fit-content;
 	transition: transform 0.3s ease;
 	padding: 1rem;
-    gap: .25rem;
-    display: flex;
-    flex-direction: column;
+	gap: .25rem;
+	display: flex;
+	flex-direction: column;
 }
 
 .mobile-menu-button {
@@ -257,7 +290,7 @@ b.dark{
 	padding: .5rem 1.2rem;
 }
 
-.dark .mobile-menu-button{
+.dark .mobile-menu-button {
 	background-color: var(--dark-brown);
 	color: var(--off-white);
 	border: .1rem solid var(--off-white);
@@ -271,145 +304,146 @@ b.dark{
 .mobile-menu-button.open::after {
 	content: "▲";
 }
+
 #optionPanel::-webkit-scrollbar {
-    width: 4px;
+	width: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
+	background: #f1f1f1;
+	border-radius: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-thumb {
-    background: #888;
-    border-radius: 4px;
+	background: #888;
+	border-radius: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-thumb:hover {
-    background: #555;
+	background: #555;
 }
 
 @media (max-width: 768px) {
-	#panelsContainer{
+	#panelsContainer {
 		padding: 3px;
 	}
-	
-	#searchContainer{
+
+	#searchContainer {
 		flex-direction: column;
 	}
-	
+
 	#optionPanel {
 		width: 100%;
 		border-right: none;
 		border-bottom: 1px solid var(--off-white);
 		padding: 0.5rem;
 	}
-	
+
 	#optionPanel.open {
-        max-height: 85vh;
-        overflow-y: auto;
-    }
-	
-	#optionPanel > .search-field,
-	#optionPanel > .search-btn{
+		max-height: 85vh;
+		overflow-y: auto;
+	}
+
+	#optionPanel>.search-field,
+	#optionPanel>.search-btn {
 		max-width: 75%;
 	}
-	
-	#optionPanel h2{
+
+	#optionPanel h2 {
 		text-align: center;
 		margin-bottom: 0.25rem;
 	}
-	
-	.search-field{
+
+	.search-field {
 		margin: 0 auto .5rem;
 	}
-	
+
 	.search-btn {
-        margin-top: 0.25rem;
-        padding: 0.4rem;
-    }
-	
-	#configuration{
+		margin-top: 0.25rem;
+		padding: 0.4rem;
+	}
+
+	#configuration {
 		flex-direction: row;
 		justify-content: space-evenly;
 		flex-wrap: wrap;
 	}
-	
-	.options{
-        padding: 0.35rem;
-        min-width: auto;
+
+	.options {
+		padding: 0.35rem;
+		min-width: auto;
 	}
-	
-	.options h3{
+
+	.options h3 {
 		font-size: 0.8rem;
-        margin-bottom: 0.15rem;
+		margin-bottom: 0.15rem;
 	}
-	
-    .options label {
-        font-size: 0.8rem;
-        padding: 0.15rem 0;
-    }
-	
+
+	.options label {
+		font-size: 0.8rem;
+		padding: 0.15rem 0;
+	}
+
 	.options-group {
-        gap: 0.5rem;
-    }
-	
+		gap: 0.5rem;
+	}
+
 	.switch-options {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 0.5rem;
-    }
-	
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.5rem;
+	}
+
 	.options input[type="checkbox"] {
-        width: 14px;
-        height: 14px;
-    }
-	
+		width: 14px;
+		height: 14px;
+	}
+
 	#bookOption label {
-        padding: 0.1rem 0;
-    }
-	
+		padding: 0.1rem 0;
+	}
+
 	#langOption label,
-    #bookOption label {
-        display: inline-block;
-        margin-right: 0.5rem;
-    }
-	
+	#bookOption label {
+		display: inline-block;
+		margin-right: 0.5rem;
+	}
+
 	.options-group {
-        grid-template-columns: repeat(2, 1fr);
-    }
-	
+		grid-template-columns: repeat(2, 1fr);
+	}
+
 	.options-group .options,
-    .switch-options .options {
-        text-align: center;
-    }
-	
+	.switch-options .options {
+		text-align: center;
+	}
+
 	.options-group label,
-    .switch-options label {
-        justify-content: center;
-    }
-	
-	.content{
+	.switch-options label {
+		justify-content: center;
+	}
+
+	.content {
 		padding: 0;
 	}
-	
-	.results{
+
+	.results {
 		gap: 5px;
 	}
-	
-	.result{
+
+	.result {
 		padding: 10px;
 	}
-	
-	.result p{
+
+	.result p {
 		line-height: 1.1;
 	}
-	
-	.mobile-menu-button {
-        	display: block;
-    }
 
-   	#optionPanel {
+	.mobile-menu-button {
+		display: block;
+	}
+
+	#optionPanel {
 		position: fixed;
 		top: -100%;
 		left: 1%;
@@ -426,28 +460,28 @@ b.dark{
 }
 
 @media (max-width: 480px) {
-	.mobile-menu-button{
+	.mobile-menu-button {
 		padding: .5rem;
 	}
-	
-    .search-field input,
-    .search-btn {
-        font-size: 16px;
-    }
-    
-    .switch-options {
-        grid-template-columns: repeat(3, 1fr);
-    }
 
-    .options {
-        padding: 0.25rem;
-    }
-	
-	#optionsPanel h3{
+	.search-field input,
+	.search-btn {
+		font-size: 16px;
+	}
+
+	.switch-options {
+		grid-template-columns: repeat(3, 1fr);
+	}
+
+	.options {
+		padding: 0.25rem;
+	}
+
+	#optionsPanel h3 {
 		text-align: center;
 	}
-	
-	.options-group .options{
+
+	.options-group .options {
 		text-align: left;
 	}
 }

--- a/advanced-search.css
+++ b/advanced-search.css
@@ -11,45 +11,44 @@ body {
 	color: var(--charcoal);
 }
 
-p {
+p{
 	margin-bottom: initial;
 }
 
-h2,
-h3 {
+h2, h3{
 	color: var(--black);
 }
 
-.links-area {
+.links-area{
 	margin: 0 3rem;
 }
 
-#panelsContainer {
+#panelsContainer{
 	display: flex;
 	flex-direction: column;
 	min-height: 90vh;
 	padding: 0px 4px;
 }
 
-#searchContainer {
+#searchContainer{
 	display: flex;
 }
 
-.dark #optionPanel {
+.dark #optionPanel{
 	background-color: var(--dark-brown);
 }
 
-#optionPanel h2 {
-	font-size: 1.1rem;
-	margin-bottom: 0.5rem;
+#optionPanel h2{
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
 }
 
-#optionPanel h3 {
+#optionPanel h3{
 	font-size: 0.9rem;
-	margin-bottom: 0.25rem;
+    margin-bottom: 0.25rem;
 }
 
-#configuration {
+#configuration{
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
@@ -60,38 +59,38 @@ h3 {
 	cursor: pointer;
 }
 
-.search-field {
+.search-field{
 	margin-bottom: 0.5rem;
 }
 
-.search-field input {
-	width: 100%;
-	padding: .5rem;
-	font-size: .9em;
-	border: 1px solid var(--lighter-gray);
+.search-field input{
+	width: 100%; 
+	padding: .5rem; 
+	font-size: .9em; 
+	border: 1px solid var(--lighter-gray); 
 	border-radius: 5px;
 }
 
-.options {
+.options{
 	margin-bottom: 0;
-	padding: 0.5rem;
-	border-radius: 4px;
-	background: rgba(0, 0, 0, 0.05);
+    padding: 0.5rem;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.03);
 }
 
 .dark .options {
-	background: rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.03);
 }
 
 .dark .search-field,
-.dark .options {
+.dark .options{
 	color: var(--off-white);
 }
 
 .options-group {
-	display: grid;
-	grid-template-columns: repeat(2, 1fr);
-	gap: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
 }
 
 .options label {
@@ -99,14 +98,14 @@ h3 {
 	flex-direction: row;
 	gap: .3rem;
 	font-size: 0.85rem;
-	padding: 0.25rem 0;
-	margin: 0;
+    padding: 0.25rem 0;
+    margin: 0;
 }
 
 .switch-options {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-	gap: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
 }
 
 .search-btn {
@@ -121,15 +120,15 @@ h3 {
 	border-radius: 5px;
 }
 
-.search-btn.red {
+.search-btn.red{
 	background-color: var(--red);
 }
 
-.dark .search-btn {
+.dark .search-btn{
 	border: 2px solid #BBB;
 }
 
-.search-btn:disabled {
+.search-btn:disabled{
 	background-color: #AAA;
 	cursor: not-allowed;
 }
@@ -138,7 +137,7 @@ h3 {
 	background-color: var(--darker-brown);
 }
 
-.search-btn.red:enabled:hover {
+.search-btn.red:enabled:hover{
 	background-color: var(--darker-red);
 }
 
@@ -160,60 +159,12 @@ h3 {
 	border-radius: 5px;
 	background-color: var(--white);
 	width: 100%;
-	border-left: 3px solid transparent;
-	transition: background-color 0.2s;
-	position: relative;
 }
 
-.result[data-type="en"] {
-	border-left-color: var(--blue);
-}
-
-.result[data-type="pli"] {
-	border-left-color: var(--orange-yellow);
-}
-
-.result[data-type="com"] {
-	border-left-color: var(--orange);
-}
-
-.result:hover {
-	background-color: #f8fafc;
-}
-
-.result h3::before {
-	text-transform: lowercase;
-	font-size: 0.7rem;
-	letter-spacing: 0.05em;
-	color: #94a3b8;
-	margin-left: .5rem;
-	display: inline-block;
-	font-weight: normal;
-	border: 1px solid #95a3b8;
-	padding: .05rem .4rem;
-	border-radius: 1rem;
-	position: absolute;
-	top: .75rem;
-	right: .75rem;
-}
-
-.result[data-type="en"] h3::before{
-	content: "english";
-}
-
-.result[data-type="pli"] h3::before{
-	content: "pāli";
-}
-
-.result[data-type="com"] h3::before{
-	content: "comment";
-}
-
-.result.placeholder {
+.result.placeholder{
 	padding: 20px;
 }
-
-.result.placeholder h1 {
+.result.placeholder h1{
 	font-size: 1.2rem;
 }
 
@@ -221,7 +172,7 @@ h3 {
 	background-color: var(--dark-brown);
 }
 
-.result>.link {
+.result > .link{
 	text-decoration: none;
 }
 
@@ -236,7 +187,7 @@ h3 {
 	line-height: 1.5;
 }
 
-.dark .result p {
+.dark .result p{
 	color: var(--off-white);
 }
 
@@ -246,11 +197,11 @@ b {
 	color: var(--light-orange);
 }
 
-b.dark {
+b.dark{
 	color: var(--dark-orange);
 }
 
-.dark b.dark {
+.dark b.dark{
 	color: var(--light-orange);
 }
 
@@ -261,7 +212,7 @@ b.dark {
 	background-color: var(--light-off-white);
 }
 
-.dark .loading-bar-container {
+.dark .loading-bar-container{
 	background-color: var(--darker-gray);
 }
 
@@ -285,9 +236,9 @@ b.dark {
 	height: fit-content;
 	transition: transform 0.3s ease;
 	padding: 1rem;
-	gap: .25rem;
-	display: flex;
-	flex-direction: column;
+    gap: .25rem;
+    display: flex;
+    flex-direction: column;
 }
 
 .mobile-menu-button {
@@ -306,7 +257,7 @@ b.dark {
 	padding: .5rem 1.2rem;
 }
 
-.dark .mobile-menu-button {
+.dark .mobile-menu-button{
 	background-color: var(--dark-brown);
 	color: var(--off-white);
 	border: .1rem solid var(--off-white);
@@ -320,146 +271,145 @@ b.dark {
 .mobile-menu-button.open::after {
 	content: "▲";
 }
-
 #optionPanel::-webkit-scrollbar {
-	width: 4px;
+    width: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-track {
-	background: #f1f1f1;
-	border-radius: 4px;
+    background: #f1f1f1;
+    border-radius: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-thumb {
-	background: #888;
-	border-radius: 4px;
+    background: #888;
+    border-radius: 4px;
 }
 
 #optionPanel::-webkit-scrollbar-thumb:hover {
-	background: #555;
+    background: #555;
 }
 
 @media (max-width: 768px) {
-	#panelsContainer {
+	#panelsContainer{
 		padding: 3px;
 	}
-
-	#searchContainer {
+	
+	#searchContainer{
 		flex-direction: column;
 	}
-
+	
 	#optionPanel {
 		width: 100%;
 		border-right: none;
 		border-bottom: 1px solid var(--off-white);
 		padding: 0.5rem;
 	}
-
+	
 	#optionPanel.open {
-		max-height: 85vh;
-		overflow-y: auto;
-	}
-
-	#optionPanel>.search-field,
-	#optionPanel>.search-btn {
+        max-height: 85vh;
+        overflow-y: auto;
+    }
+	
+	#optionPanel > .search-field,
+	#optionPanel > .search-btn{
 		max-width: 75%;
 	}
-
-	#optionPanel h2 {
+	
+	#optionPanel h2{
 		text-align: center;
 		margin-bottom: 0.25rem;
 	}
-
-	.search-field {
+	
+	.search-field{
 		margin: 0 auto .5rem;
 	}
-
+	
 	.search-btn {
-		margin-top: 0.25rem;
-		padding: 0.4rem;
-	}
-
-	#configuration {
+        margin-top: 0.25rem;
+        padding: 0.4rem;
+    }
+	
+	#configuration{
 		flex-direction: row;
 		justify-content: space-evenly;
 		flex-wrap: wrap;
 	}
-
-	.options {
-		padding: 0.35rem;
-		min-width: auto;
+	
+	.options{
+        padding: 0.35rem;
+        min-width: auto;
 	}
-
-	.options h3 {
+	
+	.options h3{
 		font-size: 0.8rem;
-		margin-bottom: 0.15rem;
+        margin-bottom: 0.15rem;
 	}
-
-	.options label {
-		font-size: 0.8rem;
-		padding: 0.15rem 0;
-	}
-
+	
+    .options label {
+        font-size: 0.8rem;
+        padding: 0.15rem 0;
+    }
+	
 	.options-group {
-		gap: 0.5rem;
-	}
-
+        gap: 0.5rem;
+    }
+	
 	.switch-options {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: 0.5rem;
-	}
-
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+    }
+	
 	.options input[type="checkbox"] {
-		width: 14px;
-		height: 14px;
-	}
-
+        width: 14px;
+        height: 14px;
+    }
+	
 	#bookOption label {
-		padding: 0.1rem 0;
-	}
-
+        padding: 0.1rem 0;
+    }
+	
 	#langOption label,
-	#bookOption label {
-		display: inline-block;
-		margin-right: 0.5rem;
-	}
-
+    #bookOption label {
+        display: inline-block;
+        margin-right: 0.5rem;
+    }
+	
 	.options-group {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
+        grid-template-columns: repeat(2, 1fr);
+    }
+	
 	.options-group .options,
-	.switch-options .options {
-		text-align: center;
-	}
-
+    .switch-options .options {
+        text-align: center;
+    }
+	
 	.options-group label,
-	.switch-options label {
-		justify-content: center;
-	}
-
-	.content {
+    .switch-options label {
+        justify-content: center;
+    }
+	
+	.content{
 		padding: 0;
 	}
-
-	.results {
+	
+	.results{
 		gap: 5px;
 	}
-
-	.result {
+	
+	.result{
 		padding: 10px;
 	}
-
-	.result p {
+	
+	.result p{
 		line-height: 1.1;
 	}
-
+	
 	.mobile-menu-button {
-		display: block;
-	}
+        	display: block;
+    }
 
-	#optionPanel {
+   	#optionPanel {
 		position: fixed;
 		top: -100%;
 		left: 1%;
@@ -476,28 +426,28 @@ b.dark {
 }
 
 @media (max-width: 480px) {
-	.mobile-menu-button {
+	.mobile-menu-button{
 		padding: .5rem;
 	}
+	
+    .search-field input,
+    .search-btn {
+        font-size: 16px;
+    }
+    
+    .switch-options {
+        grid-template-columns: repeat(3, 1fr);
+    }
 
-	.search-field input,
-	.search-btn {
-		font-size: 16px;
-	}
-
-	.switch-options {
-		grid-template-columns: repeat(3, 1fr);
-	}
-
-	.options {
-		padding: 0.25rem;
-	}
-
-	#optionsPanel h3 {
+    .options {
+        padding: 0.25rem;
+    }
+	
+	#optionsPanel h3{
 		text-align: center;
 	}
-
-	.options-group .options {
+	
+	.options-group .options{
 		text-align: left;
 	}
 }

--- a/advanced-search.css
+++ b/advanced-search.css
@@ -34,25 +34,24 @@ h2, h3{
 	display: flex;
 }
 
-#optionPanel {
-	width: 250px;
-	padding: 20px;
-	background-color: #f8f9fa;
-	border: 1px solid var(--off-white);
-	border-radius: 5px;
-}
 .dark #optionPanel{
 	background-color: var(--dark-brown);
 }
 
-#optionPanel h2 {
-	font-size: 1.2em;
-	margin-bottom: 10px;
+#optionPanel h2{
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+}
+
+#optionPanel h3{
+	font-size: 0.9rem;
+    margin-bottom: 0.25rem;
 }
 
 #configuration{
 	display: flex;
 	flex-direction: column;
+	gap: 0.5rem;
 }
 
 #configuration label,
@@ -60,17 +59,27 @@ h2, h3{
 	cursor: pointer;
 }
 
+.search-field{
+	margin-bottom: 0.5rem;
+}
+
 .search-field input{
 	width: 100%; 
-	padding: 8px; 
+	padding: .5rem; 
 	font-size: .9em; 
 	border: 1px solid var(--lighter-gray); 
 	border-radius: 5px;
 }
 
-.search-field, 
 .options{
-	margin-bottom: 20px;
+	margin-bottom: 0;
+    padding: 0.5rem;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.03);
+}
+
+.dark .options {
+    background: rgba(255, 255, 255, 0.03);
 }
 
 .dark .search-field,
@@ -78,17 +87,30 @@ h2, h3{
 	color: var(--off-white);
 }
 
+.options-group {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+}
+
 .options label {
 	display: flex;
 	flex-direction: row;
 	gap: .3rem;
-	margin: 8px 0;
-	font-size: 0.9em;
+	font-size: 0.85rem;
+    padding: 0.25rem 0;
+    margin: 0;
+}
+
+.switch-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
 }
 
 .search-btn {
-	padding: 10px;
-	margin-top: 10px;
+	padding: .5rem;
+	margin-top: .5rem;
 	width: 100%;
 	background-color: var(--dark-brown);
 	border: none;
@@ -204,16 +226,19 @@ b.dark{
 
 #optionPanel {
 	width: 250px;
-	padding: 20px;
 	background-color: #f8f9fa;
 	border: 1px solid var(--off-white);
 	border-radius: 5px;
 	position: sticky;
 	top: 0;
-    	max-height: calc(100vh - 20px);
-    	overflow-y: auto;
-    	height: fit-content;
-    	transition: transform 0.3s ease;
+	max-height: calc(100vh - 20px);
+	overflow-y: auto;
+	height: fit-content;
+	transition: transform 0.3s ease;
+	padding: 1rem;
+    gap: .25rem;
+    display: flex;
+    flex-direction: column;
 }
 
 .mobile-menu-button {
@@ -268,67 +293,161 @@ b.dark{
 	#panelsContainer{
 		padding: 3px;
 	}
+	
 	#searchContainer{
 		flex-direction: column;
 	}
+	
 	#optionPanel {
 		width: 100%;
 		border-right: none;
 		border-bottom: 1px solid var(--off-white);
-		padding: 10px 0;
+		padding: 0.5rem;
 	}
+	
+	#optionPanel.open {
+        max-height: 85vh;
+        overflow-y: auto;
+    }
+	
 	#optionPanel > .search-field,
 	#optionPanel > .search-btn{
 		max-width: 75%;
 	}
+	
 	#optionPanel h2{
 		text-align: center;
+		margin-bottom: 0.25rem;
 	}
+	
 	.search-field{
-		margin: 0 auto 20px;
+		margin: 0 auto .5rem;
 	}
+	
+	.search-btn {
+        margin-top: 0.25rem;
+        padding: 0.4rem;
+    }
+	
 	#configuration{
 		flex-direction: row;
 		justify-content: space-evenly;
 		flex-wrap: wrap;
 	}
+	
 	.options{
-		margin: 0 10px 20px;
+        padding: 0.35rem;
+        min-width: auto;
 	}
+	
+	.options h3{
+		font-size: 0.8rem;
+        margin-bottom: 0.15rem;
+	}
+	
+    .options label {
+        font-size: 0.8rem;
+        padding: 0.15rem 0;
+    }
+	
+	.options-group {
+        gap: 0.5rem;
+    }
+	
+	.switch-options {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+    }
+	
+	.options input[type="checkbox"] {
+        width: 14px;
+        height: 14px;
+    }
+	
+	#bookOption label {
+        padding: 0.1rem 0;
+    }
+	
+	#langOption label,
+    #bookOption label {
+        display: inline-block;
+        margin-right: 0.5rem;
+    }
+	
+	.options-group {
+        grid-template-columns: repeat(2, 1fr);
+    }
+	
+	.options-group .options,
+    .switch-options .options {
+        text-align: center;
+    }
+	
+	.options-group label,
+    .switch-options label {
+        justify-content: center;
+    }
+	
 	.content{
 		padding: 0;
 	}
+	
 	.results{
 		gap: 5px;
 	}
+	
 	.result{
 		padding: 10px;
 	}
+	
 	.result p{
 		line-height: 1.1;
 	}
+	
 	.mobile-menu-button {
         	display: block;
-    	}
+    }
 
-   	 #optionPanel {
-	        position: fixed;
-	        top: -100%;
-	        left: 1%;
-	        width: 98%;
-	        z-index: 999;
-	        background-color: #f8f9fa;
-	        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	        transition: top 0.3s ease;
-    	}
+   	#optionPanel {
+		position: fixed;
+		top: -100%;
+		left: 1%;
+		width: 98%;
+		z-index: 999;
+		background-color: #f8f9fa;
+		box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+		transition: top 0.3s ease;
+	}
 
-    	#optionPanel.open {
-       		top: 2.8rem;
-    	}
+	#optionPanel.open {
+		top: 2.8rem;
+	}
 }
 
 @media (max-width: 480px) {
 	.mobile-menu-button{
 		padding: .5rem;
+	}
+	
+    .search-field input,
+    .search-btn {
+        font-size: 16px;
+    }
+    
+    .switch-options {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .options {
+        padding: 0.25rem;
+    }
+	
+	#optionsPanel h3{
+		text-align: center;
+	}
+	
+	.options-group .options{
+		text-align: left;
 	}
 }

--- a/advanced-search.html
+++ b/advanced-search.html
@@ -66,33 +66,36 @@
 			<div class="content">		
 				<div class="results">
 					<div class="result placeholder">
-						<h1>Hillside Hermitage Advanced Suttas Search</h1>
+						<h1>Advanced Sutta Search</h1>
 						<br>
 						<p>
-						1. <b class="dark">Choose your language:</b> Select the language you'd like to search in. Keep in mind that some Pali terms might appear in English translations and comments.
+						1. <b class="dark">Language Selection:</b> Choose your search language. Note that some Pali terms may appear in translations and comments.
 						<br>
 						<br>
-						2. <b class="dark">Pick your books:</b> Select the specific books you want to search within.
+						2. <b class="dark">Book Selection:</b> Define which books you want to search through.
 						<br>
 						<br>
-						3. <b class="dark">Refine your search:</b> Decide if you want to find exact matches for your search terms. For example, if you search for "training", you'll only see results that contain that exact word, not words like "restraining".
+						3. <b class="dark">Exact Match:</b> Enable exact match to limit results to precise terms only.
 						<br>
 						<br>
-						4. <b class="dark">Single Results:</b> Choose whether you want to see only the first match for a given sutta.
+						4. <b class="dark">Single Result:</b> Limit display to first occurrence per sutta. For example, if you search for "training", you'll only see results that contain that exact word, not words like "restraining".
 						<br>
 						<br>
-						5. <b class="dark">Find what you are looking for:</b> Type your search terms and press Enter.
+						5. <b class="dark">Comments Only:</b> Restrict search to comments only.
+						<br>
+						<br>
+						6. <b class="dark">Search:</b> Enter your terms and press Enter.
 						<br>
 						<br>
 						<br>
-						<b class="dark">Dark mode</b>
+						<b class="dark">Dark Mode</b>
 						<br>
-						You can switch to dark mode by clicking the button at the top of the page.
+						Enable dark mode using the button at the top of the page.
 						<br>
 						<br>
-						<b class="dark">Having trouble?</b>
+						<b class="dark">Troubleshooting</b>
 						<br>
-						First, try clicking the "Reset Website" button below. If the issue persists, please report it using the "Report an error" button.
+						If you encounter issues, use the "Reset Website" button or report a problem via "Report an Error" below.
 						</p>
 					</div>
 				</div>

--- a/advanced-search.html
+++ b/advanced-search.html
@@ -31,26 +31,34 @@
 				</div>
 				
 				<div id="configuration">
-					<div id="langOption" class="options">
-						<h3>Language</h3>
-						<label><input type="checkbox" name="lang" value="en" checked> English</label>
-						<label><input type="checkbox" name="lang" value="pali"> Pali</label>
+					<div class="options-group">
+						<div id="langOption" class="options">
+							<h3>Language</h3>
+							<label><input type="checkbox" name="lang" value="en" checked> English</label>
+							<label><input type="checkbox" name="lang" value="pali"> Pali</label>
+						</div>
+						<div id="bookOption" class="options">
+							<h3>Books</h3>
+							<label><input type="checkbox" name="book" value="dn" checked> DN</label>
+							<label><input type="checkbox" name="book" value="mn" checked> MN</label>
+							<label><input type="checkbox" name="book" value="sn" checked> SN</label>
+							<label><input type="checkbox" name="book" value="an" checked> AN</label>
+							<label><input type="checkbox" name="book" value="kn" checked> KN</label>
+						</div>
 					</div>
-					<div id="bookOption" class="options">
-						<h3>Books</h3>
-						<label><input type="checkbox" name="book" value="dn" checked> DN</label>
-						<label><input type="checkbox" name="book" value="mn" checked> MN</label>
-						<label><input type="checkbox" name="book" value="sn" checked> SN</label>
-						<label><input type="checkbox" name="book" value="an" checked> AN</label>
-						<label><input type="checkbox" name="book" value="kn" checked> KN</label>
-					</div>
-					<div id="strictOption" class="options">
-						<h3>Exact Match</h3>
-						<label><input type="checkbox" name="book" value="strict"> On</label>
-					</div>
-					<div id="singleResultOption" class="options">
-						<h3>Single Result</h3>
-						<label><input type="checkbox" name="book" value="single"> On</label>
+					<div class="switch-options">
+						<div id="strictOption" class="options">
+							<h3>Exact Match</h3>
+							<label><input type="checkbox" name="book" value="strict"> On</label>
+						</div>
+						<div id="singleResultOption" class="options">
+							<h3>Single Result</h3>
+							<label><input type="checkbox" name="book" value="single"> On</label>
+						</div>
+						<div id="commentsOption" class="options">
+							<h3>Comments Only</h3>
+							<label><input type="checkbox" name="comments" value="comments"> On</label>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/advanced-search.html
+++ b/advanced-search.html
@@ -9,8 +9,8 @@
 	<link rel="stylesheet" href="advanced-search.css">
 	<script>
         (function() {
-			// While waiting body to be displayed we apply .dark on html to prevent flashing
-			document.documentElement.classList.add(localStorage.theme);
+            // While waiting body to be displayed we apply .dark on html to prevent flashing
+            document.documentElement.classList.add(localStorage.theme);
             document.documentElement.classList.add('theme-loaded');
         })();
     </script>

--- a/advanced-search.html
+++ b/advanced-search.html
@@ -66,7 +66,7 @@
 			<div class="content">		
 				<div class="results">
 					<div class="result placeholder">
-						<h1>Advanced Sutta Search</h1>
+						<h1>Hillside Hermitage - Advanced Sutta Search</h1>
 						<br>
 						<p>
 						1. <b class="dark">Language Selection:</b> Choose your search language. Note that some Pali terms may appear in translations and comments.

--- a/advanced-search.html
+++ b/advanced-search.html
@@ -75,10 +75,10 @@
 						2. <b class="dark">Book Selection:</b> Define which books you want to search through.
 						<br>
 						<br>
-						3. <b class="dark">Exact Match:</b> Enable exact match to limit results to precise terms only.
+						3. <b class="dark">Exact Match:</b> Enable exact match to limit results to precise terms only. For example, if you search for "training", you'll only see results that contain that exact word, not words like "restraining".
 						<br>
 						<br>
-						4. <b class="dark">Single Result:</b> Limit display to first occurrence per sutta. For example, if you search for "training", you'll only see results that contain that exact word, not words like "restraining".
+						4. <b class="dark">Single Result:</b> Limit display to first occurrence per sutta.
 						<br>
 						<br>
 						5. <b class="dark">Comments Only:</b> Restrict search to comments only.

--- a/js/utils/contentSections/addResultToDOM.js
+++ b/js/utils/contentSections/addResultToDOM.js
@@ -1,7 +1,8 @@
-export function addResultToDOM(title, snippet, link, options = {}) {
+export function addResultToDOM(title, snippet, link, options = {}, dataType) {
     const resultsDiv = document.querySelector('.results');
     const resultDiv = document.createElement('div');
     resultDiv.classList.add('result');
+	resultDiv.setAttribute('data-type', dataType);
 
     let anchor;
     if (link != "none") {
@@ -28,10 +29,10 @@ export function addResultToDOM(title, snippet, link, options = {}) {
     resultsDiv.appendChild(resultDiv);
 }
 
-export function addResultToDOMAsync(title, snippet, link, options) {
+export function addResultToDOMAsync(title, snippet, link, options, dataType) {
     return new Promise((resolve) => {
         setTimeout(() => {
-            addResultToDOM(title, snippet, link, options);
+            addResultToDOM(title, snippet, link, options, dataType);
             resolve();
         }, 0);
     });

--- a/js/utils/contentSections/addResultToDOM.js
+++ b/js/utils/contentSections/addResultToDOM.js
@@ -1,9 +1,9 @@
 export function addResultToDOM(title, snippet, link, options = {}, dataType) {
-    const resultsDiv = document.querySelector(".results");
-    const resultDiv = document.createElement("div");
-    resultDiv.classList.add("result");
-	resultDiv.setAttribute("data-type", dataType);
-	
+    const resultsDiv = document.querySelector('.results');
+    const resultDiv = document.createElement('div');
+    resultDiv.classList.add('result');
+	resultDiv.setAttribute('data-type', dataType);
+
     let anchor;
     if (link != "none") {
         anchor = document.createElement('a');
@@ -14,23 +14,6 @@ export function addResultToDOM(title, snippet, link, options = {}, dataType) {
 
     const titleElement = document.createElement('h3');
     titleElement.innerHTML = title;
-	
-	let typeLabel = document.createElement('span');
-	switch(dataType){
-		case "en":
-			typeLabel.textContent = "english";
-			break;
-			
-		case "pli":
-			typeLabel.textContent = "pāli";
-			break;
-			
-		case "com":
-			typeLabel.textContent = "comment";
-			break;
-	}
-	
-	titleElement.appendChild(typeLabel);
 
     const preview = document.createElement('p');
     preview.innerHTML = snippet;

--- a/js/utils/contentSections/addResultToDOM.js
+++ b/js/utils/contentSections/addResultToDOM.js
@@ -1,9 +1,9 @@
 export function addResultToDOM(title, snippet, link, options = {}, dataType) {
-    const resultsDiv = document.querySelector('.results');
-    const resultDiv = document.createElement('div');
-    resultDiv.classList.add('result');
-	resultDiv.setAttribute('data-type', dataType);
-
+    const resultsDiv = document.querySelector(".results");
+    const resultDiv = document.createElement("div");
+    resultDiv.classList.add("result");
+	resultDiv.setAttribute("data-type", dataType);
+	
     let anchor;
     if (link != "none") {
         anchor = document.createElement('a');
@@ -14,6 +14,23 @@ export function addResultToDOM(title, snippet, link, options = {}, dataType) {
 
     const titleElement = document.createElement('h3');
     titleElement.innerHTML = title;
+	
+	let typeLabel = document.createElement('span');
+	switch(dataType){
+		case "en":
+			typeLabel.textContent = "english";
+			break;
+			
+		case "pli":
+			typeLabel.textContent = "pāli";
+			break;
+			
+		case "com":
+			typeLabel.textContent = "comment";
+			break;
+	}
+	
+	titleElement.appendChild(typeLabel);
 
     const preview = document.createElement('p');
     preview.innerHTML = snippet;

--- a/js/utils/contentSections/searchSuttasWithStop.js
+++ b/js/utils/contentSections/searchSuttasWithStop.js
@@ -121,7 +121,7 @@ class ContentProcessor {
         await addResultToDOMAsync(
             finalDisplayTitle,
             firstPassage,
-            `${window.location.origin}/?q=${sutta.id}&search=${this.resultProcessor.searchTermUrl}&pali=${isPali ? 'show' : this.resultProcessor.options.pali ? 'show' : 'hide'}`,
+            `${window.location.origin}/?q=${sutta.id}&search=${this.resultProcessor.searchTermUrl}&pali=hide`,
             { target: "_blank" },
             isPali ? "pli" : "en"
         );
@@ -163,7 +163,7 @@ class ContentProcessor {
                 await addResultToDOMAsync(
                     finalDisplayTitle,
                     result.passage,
-                    `${window.location.origin}/?q=${sutta.id}&search=${this.resultProcessor.searchTermUrl}&pali=${this.resultProcessor.options.pali ? 'show' : 'hide'}#${result.verseRange}`,
+                    `${window.location.origin}/?q=${sutta.id}&search=${this.resultProcessor.searchTermUrl}&pali=hide#${result.verseRange}`,
                     { target: "_blank" },
                     "en"
                 );


### PR DESCRIPTION
#### - Added search on comments only
- Will display comments only even if 'en' and 'pali' are disabled, or if 'en' is disabled and 'pali' is enabled.

#### - Added checkbox "Comments Only"

#### - Added text related to 'Comments Only' and modified the presentation text

#### - Fixed result order when 'en' and 'pali' are enabled
- Right now the results are mixed between english and pali. Aims to always display translation first, then comment, then pali for a given sutta.

#### - Added lang next to title
- ~~When 'en' and 'pali' are enabled, added ```[EN]``` and ```[PLI]``` next to title to differentiate them at first glance.~~ [Similar modification added in next PR]
- ~~Also changed ```Title - Comments``` to ```Title [Comments]``` for comment related results.~~ [Similar modification added in next PR]

#### - Modified CSS to make the option panel more compact on desktop and mobile
