### PR TITLE
Offline caching stability fix

### DIFF
--- a/js/utils/eventListeners/activateCacheButton.js
+++ b/js/utils/eventListeners/activateCacheButton.js
@@ -18,7 +18,7 @@ export default function activateCacheButton()
           {
             console.log(error);
             // TODO maybe a red colour box here?
-            showNotification("An error occurred while attempting to download. Please refresh the page, wait a few seconds, and retry");
+            showNotification("An error occurred while attempting to download. Please check your internet connection, refresh the page, wait a few seconds, and retry");
           }
         }
       });

--- a/sw.js
+++ b/sw.js
@@ -37,7 +37,26 @@ self.addEventListener('message', event => {
 });
 
 async function cacheFilesInBatches(files) {
+  // Check if the user is online
+  if (!navigator.onLine) {
+    // If the user is offline, notify and exit
+    notifyClients('cachingError');
+    return;
+  }
+
+  // If the user is online, continue with caching
+  // Delete the old cache if it exists
+  const cacheNames = await caches.keys();
+  for (const oldCacheName of cacheNames) {
+    if (oldCacheName !== cacheName) {
+      await caches.delete(oldCacheName); // Delete obsolete caches
+    }
+  }
+
+  // Open or create the cache with the new name
   const cache = await caches.open(cacheName);
+  
+  // Add the files in batches to the cache
   for (let i = 0; i < files.length; i += BATCH_SIZE) {
     const batch = files.slice(i, i + BATCH_SIZE);
     let retries = 0;
@@ -45,17 +64,19 @@ async function cacheFilesInBatches(files) {
 
     while (retries < MAX_RETRIES && !success) {
       try {
-        await cacheBatchWithTimeout(cache, batch);
+        await cacheBatchWithTimeout(cache, batch); // Add the batch to the cache
         success = true;
       } catch (error) {
         retries++;
         if (retries === MAX_RETRIES) {
           notifyClients('cachingError');
+          caches.delete(cacheName);
           return;
         }
       }
     }
   }
+
   notifyClients('cachingSuccess');
 }
 
@@ -64,11 +85,7 @@ async function cacheBatchWithTimeout(cache, batch) {
     let timeoutId = setTimeout(() => reject(new Error('Timeout')), TIMEOUT);
 
     Promise.all(batch.map(async file => {
-      // Delete file if it already exists within the cache
-      const request = new Request(file);
-      await cache.delete(request);
-
-      // Then, add new version of the file within the cache
+      // Caches file
       return cache.add(file).catch(() => {
         console.error('Caching failed for resource:', file);
         throw new Error('Fetch failed');

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const version = 'v8'; // Update this version manually when filesToCache changes
+const version = 'v8';
 
 // static files to cache
 const filesToCache = [
@@ -11,6 +11,7 @@ const filesToCache = [
   "index.html",
   "index.js",
 ];
+
 // Load additional files from files_to_cache.json and add them to filesToCache
 fetch('../../python/generated/files_to_cache.json')
   .then(response => response.json())


### PR DESCRIPTION
- Revert the previous PR: Instead of deleting each files before caching their new version, delete all previous cache versions and create a new one -> prevents the need to modify the caching version everytime a file is manually added to `sw.js`.
- Remove the current cache if there were errors during the caching -> prevents issues like #267 one.
- Don't start the caching process if the user is not connected to internet.
- Warn the user that the caching error may come from internet connection issues.