### PR TITLE
Fix some issues

### DIFF
--- a/index.css
+++ b/index.css
@@ -1194,8 +1194,6 @@ bookmarkButton {
   }
 }
 
-/* Additional enhancements for elegance and readability */
-
 #top-buttons.button-container {
   display: flex;
   flex-direction: row;
@@ -1223,8 +1221,8 @@ bookmarkButton {
   text-decoration: none;
 }
 
-#top-buttons .icon-button:hover {
-  background-color: var(--off-white);
+#top-buttons .icon-button.active {
+  background-color: var(--off-white); 
   color: var(--darker-brown);
 }
 
@@ -1232,8 +1230,15 @@ bookmarkButton {
   color: var(--off-white);
 }
 
-.dark #top-buttons .icon-button:hover {
-  color: var(--darker-brown);
+@media (hover: hover) { /* Only on screen supporting hover */
+  #top-buttons .icon-button:hover {
+    background-color: var(--off-white);
+    color: var(--darker-brown);
+  }
+  
+  .dark #top-buttons .icon-button:hover {
+    color: var(--darker-brown);
+  }
 }
 
 #home-button svg,

--- a/js/utils/eventListeners/activateCacheButton.js
+++ b/js/utils/eventListeners/activateCacheButton.js
@@ -21,8 +21,8 @@ export default function activateCacheButton()
             showNotification("An error occurred while attempting to download. Please check your internet connection, refresh the page, wait a few seconds, and retry");
           }
         }
-		else{
-			showNotification("Your browser does not support offline functionality.<br/>Please update your browser or use another one.");
-		}
+        else{
+            showNotification("Your browser does not support offline functionality.<br/>Please update your browser or use another one.");
+        }
       });
 }

--- a/js/utils/eventListeners/activateCacheButton.js
+++ b/js/utils/eventListeners/activateCacheButton.js
@@ -18,8 +18,11 @@ export default function activateCacheButton()
           {
             console.log(error);
             // TODO maybe a red colour box here?
-            showNotification("An error occurred while attempting to download. Please refresh the page, wait a few seconds, and retry");
+            showNotification("An error occurred while attempting to download. Please check your internet connection, refresh the page, wait a few seconds, and retry");
           }
         }
+		else{
+			showNotification("Your browser does not support offline functionality.<br/>Please update your browser or use another one.");
+		}
       });
 }

--- a/js/utils/eventListeners/activateMessageListener.js
+++ b/js/utils/eventListeners/activateMessageListener.js
@@ -5,11 +5,12 @@ export default function activateMessageListener()
     const SUCCESS_MSG = "Download successful - site available offline.";
     const FAIL_MSG = "Caching error. Please clear site data, refresh the page, and try again."
 
-
-    navigator.serviceWorker.addEventListener('message', event => 
-    {
-        if(!event.data) return;
-        if (event.data.action === 'cachingSuccess') showNotification(SUCCESS_MSG)
-        if (event.data.action === 'cachingError') showNotification(FAIL_MSG);
-    });
+    if (navigator.serviceWorker){
+        navigator.serviceWorker.addEventListener('message', event => 
+        {
+            if(!event.data) return;
+            if (event.data.action === 'cachingSuccess') showNotification(SUCCESS_MSG)
+            if (event.data.action === 'cachingError') showNotification(FAIL_MSG);
+        });
+    }
 }

--- a/js/utils/eventListeners/activateSideBySideEventListenerKeyUp.js
+++ b/js/utils/eventListeners/activateSideBySideEventListenerKeyUp.js
@@ -7,7 +7,7 @@ export default function activateSideBySideEventListenerKeyUp()
     document.onkeyup = function (e)
     {
         const paliHidden = document.getElementById("sutta").classList.contains("hide-pali");
-        if(paliHidden || e.target.id === 'search-bar' || e.key !== 's') return;
+        if(paliHidden || e.target.id === 'filter-bar' || e.key !== 's') return;
 
         if (localStorage.sideBySide === "true") 
         {

--- a/js/utils/eventListeners/activateTopButtonsTouchAnimation.js
+++ b/js/utils/eventListeners/activateTopButtonsTouchAnimation.js
@@ -1,19 +1,22 @@
 export default function activateTopButtonsTouchAnimation()
 {
-    const buttons = document.querySelectorAll("#top-buttons .icon-button");
+    //Only on touchscreen device
+    if ("ontouchstart" in window || navigator.maxTouchPoints) {
+        const buttons = document.querySelectorAll("#top-buttons .icon-button");
 
-    buttons.forEach(button => {
-        button.addEventListener("touchstart", function (e) {
-            button.classList.add("active");
-            e.preventDefault();
-        });
+        buttons.forEach(button => {
+            button.addEventListener("touchstart", function (e) {
+                button.classList.add("active");
+                e.preventDefault();
+            });
 
-        button.addEventListener("touchend", function () {
-            button.classList.remove("active");
-        });
+            button.addEventListener("touchend", function () {
+                button.classList.remove("active");
+            });
 
-        button.addEventListener("touchcancel", function () {
-            button.classList.remove("active");
+            button.addEventListener("touchcancel", function () {
+                button.classList.remove("active");
+            });
         });
-    });
+    }
 }

--- a/js/utils/eventListeners/activateTopButtonsTouchAnimation.js
+++ b/js/utils/eventListeners/activateTopButtonsTouchAnimation.js
@@ -1,0 +1,19 @@
+export default function activateTopButtonsTouchAnimation()
+{
+    const buttons = document.querySelectorAll("#top-buttons .icon-button");
+
+    buttons.forEach(button => {
+        button.addEventListener("touchstart", function (e) {
+            button.classList.add("active");
+            e.preventDefault();
+        });
+
+        button.addEventListener("touchend", function () {
+            button.classList.remove("active");
+        });
+
+        button.addEventListener("touchcancel", function () {
+            button.classList.remove("active");
+        });
+    });
+}

--- a/js/utils/loadContent/activateEventListeners.js
+++ b/js/utils/loadContent/activateEventListeners.js
@@ -22,6 +22,7 @@ import activateHashChangeListener from "../eventListeners/activateHashChangeList
 import activateHandleTextSelection from "../eventListeners/activateHandleTextSelection.js";
 import activateYoutubePreview from '../eventListeners/activateYoutubePreview.js';
 import initializeFuse from '../eventListeners/initializeFuse.js';
+import activateTopButtonsTouchAnimation from '../eventListeners/activateTopButtonsTouchAnimation.js';
 
 export function activateEventListeners(availableSuttasJson)
 {
@@ -35,7 +36,8 @@ export function activateEventListeners(availableSuttasJson)
     activateEPUBInfoButton();
     activateDownloadEPUBButton();
     activateMessageListener();
-    
+    activateTopButtonsTouchAnimation();
+	
     if (!window.location.href.endsWith("/bookmarks.html") 
     && !window.location.href.endsWith("/glossary.html") 
     && !window.location.href.endsWith("/comments.html") 


### PR DESCRIPTION
- Modify Side-By-Side Pali display activation conditions: a change was needed since `#search-bar` became `#filter-bar`, otherwise it is possible that the side-by-side mode is activated by typing "s" in the filter bar.
- Add a click animation on the top buttons on mobile, the usual hover animation stays as long as the user is pressing the button. (most useful for the `Theme` button, since the others send the user to another page, refreshing the buttons in the process)
- Make sure that `navigator.serviceworker` is set and available before using it anywhere. So we don't get a js error and all the other js code not working because of it.

closes #270 