### PR TITLE
Fix hidden line when coming back from comment

### DIFF
--- a/js/utils/loadContent/addNavbar.js
+++ b/js/utils/loadContent/addNavbar.js
@@ -1,38 +1,38 @@
+import { isHashScrolling } from './../navigation/scrollToHash.js';
+
 export function addNavbar() {
     const navbar = document.createElement('div');
     navbar.id = 'suttanav';
     navbar.innerHTML = document.title;
     document.body.appendChild(navbar);
-  
+
     let lastScrollTop = 0;
     let isVisible = false;
     let scrollTimer = null;
-    
+
     window.addEventListener('scroll', () => {
+        if (isHashScrolling) return; // Ignore navbar visibility updates during hash-based scrolling
+
         if (scrollTimer !== null) {
             clearTimeout(scrollTimer);
         }
 
         const currentScrollTop = window.scrollY || document.documentElement.scrollTop;
-        
-        // Show navbar when scrolling up beyond threshold
+
         if (currentScrollTop < lastScrollTop && currentScrollTop > 170) {
             if (!isVisible) {
                 navbar.style.top = '0';
                 isVisible = true;
             }
-        } 
-        // Hide navbar when at top or scrolling down
-        else if (currentScrollTop <= 170 || currentScrollTop > lastScrollTop) {
+        } else if (currentScrollTop <= 170 || currentScrollTop > lastScrollTop) {
             if (isVisible) {
                 navbar.style.top = '-50px';
                 isVisible = false;
             }
         }
-        
+
         lastScrollTop = currentScrollTop;
-        
-        // Reset scroll state after scrolling stops
+
         scrollTimer = setTimeout(() => {
             scrollTimer = null;
         }, 150);

--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -1,50 +1,52 @@
+export let isHashScrolling = false;
+
 import { highlightSegments } from './highlightSegments.js';
 
 export function scrollToHash() {
-    const fullHash = window.location.hash.substring(1); // Remove the '#' from the hash
-  
-    // Split on `~` to separate the hash part from any options
+    const fullHash = window.location.hash.substring(1);
     const [hash, options] = fullHash.split('~');
-  
-    // Check for the quick-highlight or no-highlight options in the URL
+
     const isQuickHighlight = options && options.includes('quick-highlight');
     const isNoHighlight = options && options.includes('no-highlight');
-  
-    // Remove existing highlights from all comment elements
+
     document.querySelectorAll(".comment-highlight").forEach(el => el.classList.remove("comment-highlight"));
-  
+
     if (hash.startsWith('comment')) {
         const commentElement = document.getElementById(hash);
         if (commentElement) {
+            isHashScrolling = true;
             commentElement.classList.add("comment-highlight");
             commentElement.scrollIntoView({ block: "start" });
-            window.scrollBy(0, -60); // Adjusts scroll to be a few lines below
+            window.scrollBy(0, -60);
+            setTimeout(() => { isHashScrolling = false; }, 500);
         }
     } else if (hash) {
-        // Check if it's a range (contains underscore)
         const isRange = hash.includes('_');
-        
+
         if (isRange) {
             const [startId, endId] = hash.split('_');
             const startElement = document.getElementById(startId);
             const endElement = document.getElementById(endId);
-            
+
             if (startElement) {
+                isHashScrolling = true;
                 if (!isNoHighlight) {
                     highlightSegments(startElement, endElement, isQuickHighlight);
                 }
                 startElement.scrollIntoView({ block: "start" });
                 window.scrollBy(0, -60);
+                setTimeout(() => { isHashScrolling = false; }, 500);
             }
         } else {
-            // Handle single element case
             const targetElement = document.getElementById(hash);
             if (targetElement) {
+                isHashScrolling = true;
                 if (!isNoHighlight) {
                     highlightSegments(targetElement, null, isQuickHighlight);
                 }
                 targetElement.scrollIntoView({ block: "start" });
                 window.scrollBy(0, -60);
+                setTimeout(() => { isHashScrolling = false; }, 500);
             }
         }
     }

--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -10,11 +10,15 @@ export function scrollToHash() {
     const isQuickHighlight = options && options.includes('quick-highlight');
     const isNoHighlight = options && options.includes('no-highlight');
   
+    // Remove existing highlights from all comment elements
+    document.querySelectorAll(".comment-highlight").forEach(el => el.classList.remove("comment-highlight"));
+  
     if (hash.startsWith('comment')) {
         const commentElement = document.getElementById(hash);
         if (commentElement) {
             commentElement.classList.add("comment-highlight");
-            commentElement.scrollIntoView();
+            commentElement.scrollIntoView({ block: "start" });
+            window.scrollBy(0, -60); // Adjusts scroll to be a few lines below
         }
     } else if (hash) {
         // Check if it's a range (contains underscore)
@@ -29,7 +33,8 @@ export function scrollToHash() {
                 if (!isNoHighlight) {
                     highlightSegments(startElement, endElement, isQuickHighlight);
                 }
-                startElement.scrollIntoView();
+                startElement.scrollIntoView({ block: "start" });
+                window.scrollBy(0, -60);
             }
         } else {
             // Handle single element case
@@ -38,10 +43,9 @@ export function scrollToHash() {
                 if (!isNoHighlight) {
                     highlightSegments(targetElement, null, isQuickHighlight);
                 }
-                targetElement.scrollIntoView();
+                targetElement.scrollIntoView({ block: "start" });
+                window.scrollBy(0, -60);
             }
         }
     }
-
 }
-


### PR DESCRIPTION
- Don't show navbar when the scroll is done because of scrollToHash(): the navbar will not be shown when the user click to the ```←``` to come back from where he left off.
- When using a link to a comment, or a link back from a comment to a passage -> additionnaly scroll down ~4-5 lines so the comment, or the passage where the user left off, isn't directly at the very top of the page.

closes #278 