### PR TITLE
Add space in sutta IDs on homepage

### DIFF
--- a/js/utils/contentSections/displaySuttas.js
+++ b/js/utils/contentSections/displaySuttas.js
@@ -25,7 +25,7 @@ export function displaySuttas(suttas, isSearch = false)
     }
   
     suttaArea.innerHTML += `<ul>${Object.entries(suttas).map(([sutta_id, sutta_details]) => {
-		const id = sutta_details['id'].replace(/\s+/g, '');
+		const id = sutta_details['id'];
 		const title = sutta_details['title'];
 		const pali_title = sutta_details['pali_title'];
 		const hasDescription = sutta_details['description'];
@@ -45,7 +45,7 @@ export function displaySuttas(suttas, isSearch = false)
 			: '';
 
 		const card = `<li class="sutta-card">
-			<a href="/?q=${id.toLowerCase()}">
+			<a href="/?q=${id.toLowerCase().replace(/\s+/g, '')}">
 				<div class="sutta-card-content">
 					<div class="sutta-card-top">
 						<div class="sutta-title">${id} — ${title}</div>

--- a/js/utils/contentSections/loadWhatsNewArea.js
+++ b/js/utils/contentSections/loadWhatsNewArea.js
@@ -35,11 +35,11 @@ export function loadWhatsNewArea(availableSuttasJson) {
         whatsNewArea.innerHTML = `<h2>What's New</h2>` +
             `<div class="whats-new-container">
                 ${recentSuttas.map(sutta => {
-                    const id = sutta.id.replace(/\s+/g, '');
+                    const id = sutta.id;
                     const title = sutta.title;
                     const daysAgoAdded = daysAgo(sutta.date_added); // Calculer combien de jours depuis l'ajout
                     return `
-                        <a class="sutta-box" href="/?q=${id.toLowerCase()}">
+                        <a class="sutta-box" href="/?q=${id.toLowerCase().replace(/\s+/g, '')}">
                             <h3 class="sutta-card-title">${title}</h3>
                             <div class="sutta-pali-title">${id} — ${sutta.pali_title}</div>
                             <div class="sutta-date-added"><small>Added ${daysAgoAdded}</small></div>


### PR DESCRIPTION
Add space between letters and numbers in sutta IDs displayed on the home page (e.g.: ```MN44``` becomes ```MN 44```).

Feel free to dismiss/close if not appropriate.