### PR TITLE
Fix auto scroll issue

### DIFF
--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -2,14 +2,20 @@ export let isHashScrolling = false;
 
 import { highlightSegments } from './highlightSegments.js';
 
-function scrollWithOffset() {
+function scrollWithOffset(element) {
     // Check the available space below the current scroll position
     const spaceBelow = document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
-    if (spaceBelow > 60) {
-        window.scrollBy(0, -60); // Scroll up by 60px
-    } else {
-        window.scrollBy(0, -spaceBelow); // Scroll just enough to avoid hiding
-    }
+	
+	//setTimeout to scroll after youtube links are loaded so the position isn't shifted because of it
+	setTimeout(() => {
+		element.scrollIntoView({ block: "start" });
+		/* If there isn't 60px below the current scroll position,
+		element.scrollIntoView() above has put the element at the bottom of the page,
+		therefore scrolling up would result in hiding it or part of it */
+		if (spaceBelow > 60) {
+			window.scrollBy(0, -60); // Scroll up by 60px
+		} 
+	}, 100);
 }
 
 export function scrollToHash() {
@@ -26,8 +32,7 @@ export function scrollToHash() {
         if (commentElement) {
             isHashScrolling = true;
             commentElement.classList.add("comment-highlight");
-            commentElement.scrollIntoView({ block: "start" });
-            scrollWithOffset();
+            scrollWithOffset(commentElement);
             setTimeout(() => { isHashScrolling = false; }, 500);
         }
     } else if (hash) {
@@ -43,8 +48,7 @@ export function scrollToHash() {
                 if (!isNoHighlight) {
                     highlightSegments(startElement, endElement, isQuickHighlight);
                 }
-                startElement.scrollIntoView({ block: "start" });
-                scrollWithOffset();
+                scrollWithOffset(startElement);
                 setTimeout(() => { isHashScrolling = false; }, 500);
             }
         } else {
@@ -54,8 +58,7 @@ export function scrollToHash() {
                 if (!isNoHighlight) {
                     highlightSegments(targetElement, null, isQuickHighlight);
                 }
-                targetElement.scrollIntoView({ block: "start" });
-                scrollWithOffset();
+                scrollWithOffset(targetElement);
                 setTimeout(() => { isHashScrolling = false; }, 500);
             }
         }

--- a/js/utils/navigation/scrollToHash.js
+++ b/js/utils/navigation/scrollToHash.js
@@ -2,6 +2,16 @@ export let isHashScrolling = false;
 
 import { highlightSegments } from './highlightSegments.js';
 
+function scrollWithOffset() {
+    // Check the available space below the current scroll position
+    const spaceBelow = document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
+    if (spaceBelow > 60) {
+        window.scrollBy(0, -60); // Scroll up by 60px
+    } else {
+        window.scrollBy(0, -spaceBelow); // Scroll just enough to avoid hiding
+    }
+}
+
 export function scrollToHash() {
     const fullHash = window.location.hash.substring(1);
     const [hash, options] = fullHash.split('~');
@@ -17,7 +27,7 @@ export function scrollToHash() {
             isHashScrolling = true;
             commentElement.classList.add("comment-highlight");
             commentElement.scrollIntoView({ block: "start" });
-            window.scrollBy(0, -60);
+            scrollWithOffset();
             setTimeout(() => { isHashScrolling = false; }, 500);
         }
     } else if (hash) {
@@ -34,7 +44,7 @@ export function scrollToHash() {
                     highlightSegments(startElement, endElement, isQuickHighlight);
                 }
                 startElement.scrollIntoView({ block: "start" });
-                window.scrollBy(0, -60);
+                scrollWithOffset();
                 setTimeout(() => { isHashScrolling = false; }, 500);
             }
         } else {
@@ -45,7 +55,7 @@ export function scrollToHash() {
                     highlightSegments(targetElement, null, isQuickHighlight);
                 }
                 targetElement.scrollIntoView({ block: "start" });
-                window.scrollBy(0, -60);
+                scrollWithOffset();
                 setTimeout(() => { isHashScrolling = false; }, 500);
             }
         }


### PR DESCRIPTION
- Only scroll up to show previous line if the linked passage isn't at the bottom of the page, which would result in hiding it or part of it.

- Also, fixed an issue where the auto scroll to the linked comment was made before youtube links were displayed correctly, resulting in the scroll position being shifted and the linked comment hidden because of it, in some cases.

closes #282 