### PR TITLE
Fix mobile header not displaying properly on some screensizes

### DIFF
--- a/index.css
+++ b/index.css
@@ -1340,7 +1340,6 @@ bookmarkButton {
 }
 
 @media only screen and (max-width: 768px) {
-
   /* CSS rules for screens smaller than 768px */
   .comment-text {
     width: 300px;
@@ -1431,13 +1430,6 @@ bookmarkButton {
   .sutta-card-bottom {
     padding-top: 2px;
     border-top: 1px solid rgba(0, 0, 0, 0.08);
-  }
-
-  .dark #cacheButton,
-  .dark #downloadEpubButton {
-    background-color: var(--dark-blue);
-    color: var(--off-white);
-    border-color: var(--off-white);
   }
 }
 

--- a/index.css
+++ b/index.css
@@ -1326,6 +1326,19 @@ bookmarkButton {
   font-family: "Roboto Medium";
 }
 
+@media only screen and (max-width: 1000px) {
+  #top-buttons.button-container {
+    margin-top: initial;
+  }
+  
+  .dark #cacheButton,
+  .dark #downloadEpubButton {
+    background-color: var(--dark-blue);
+    color: var(--off-white);
+    border-color: var(--off-white);
+  }
+}
+
 @media only screen and (max-width: 768px) {
 
   /* CSS rules for screens smaller than 768px */
@@ -1336,10 +1349,6 @@ bookmarkButton {
 
   .bookmark-container p {
     max-width: 60%;
-  }
-
-  #top-buttons.button-container {
-    margin-top: initial;
   }
 
   .links-area {

--- a/js/utils/eventListeners/activateWindowEventListeners.js
+++ b/js/utils/eventListeners/activateWindowEventListeners.js
@@ -6,7 +6,7 @@ export default function activateWindowEventListeners() {
   const header = document.querySelector(".mobile-header");
   let lastScrollY = window.scrollY;
 
-  window.matchMedia("(max-width: 1000px)").addEventListener("change", (event) => {
+  window.matchMedia("(max-width: 768px)").addEventListener("change", (event) => {
     if (event.matches) {
       document.getElementById("footer").innerHTML = "";
       fetchHeader("/header-mobile.html");

--- a/js/utils/eventListeners/activateWindowEventListeners.js
+++ b/js/utils/eventListeners/activateWindowEventListeners.js
@@ -6,7 +6,7 @@ export default function activateWindowEventListeners() {
   const header = document.querySelector(".mobile-header");
   let lastScrollY = window.scrollY;
 
-  window.matchMedia("(max-width: 768px)").addEventListener("change", (event) => {
+  window.matchMedia("(max-width: 1000px)").addEventListener("change", (event) => {
     if (event.matches) {
       document.getElementById("footer").innerHTML = "";
       fetchHeader("/header-mobile.html");


### PR DESCRIPTION
In the CSS the mobile header is configured to be rightly displayed from 768px and below so went from mobile header being displayed from 1000px and below to 768px and below (width of screens/windows).

closes #287 