### PR TITLE
Moves the Search Panel button on mobile when header is hidden

### DIFF
--- a/index.css
+++ b/index.css
@@ -1326,6 +1326,19 @@ bookmarkButton {
   font-family: "Roboto Medium";
 }
 
+@media only screen and (max-width: 1000px) {
+  #top-buttons.button-container {
+    margin-top: initial;
+  }
+  
+  .dark #cacheButton,
+  .dark #downloadEpubButton {
+    background-color: var(--dark-blue);
+    color: var(--off-white);
+    border-color: var(--off-white);
+  }
+}
+
 @media only screen and (max-width: 768px) {
 
   /* CSS rules for screens smaller than 768px */
@@ -1336,10 +1349,6 @@ bookmarkButton {
 
   .bookmark-container p {
     max-width: 60%;
-  }
-
-  #top-buttons.button-container {
-    margin-top: initial;
   }
 
   .links-area {
@@ -1424,11 +1433,8 @@ bookmarkButton {
     border-top: 1px solid rgba(0, 0, 0, 0.08);
   }
 
-  .dark #cacheButton,
-  .dark #downloadEpubButton {
-    background-color: var(--dark-blue);
-    color: var(--off-white);
-    border-color: var(--off-white);
+  #top-buttons.hidden ~ .mobile-search-panel-button{
+    top: 5px !important;	  
   }
 }
 

--- a/js/utils/eventListeners/initializeSearchEvents.js
+++ b/js/utils/eventListeners/initializeSearchEvents.js
@@ -1,12 +1,14 @@
 import { startSearch } from '../userActions/startSearch.js';
 import { searchState } from '../userActions/searchState.js';
 
-export function initializeSearchEvents() {
+export default function initializeSearchEvents() {
     // Add button for mobile
     const mobileButton = document.createElement('button');
     mobileButton.className = 'mobile-search-panel-button';
     mobileButton.textContent = 'Search Panel';
-    document.body.insertBefore(mobileButton, document.body.firstChild);
+	const header_placeholder = document.getElementById('header-placeholder');
+	const hamburger = document.getElementById('hamburger-menu');
+    header_placeholder.insertBefore(mobileButton, hamburger);
     
     const optionPanel = document.getElementById('optionPanel');
     const searchButton = document.getElementById('searchButton');

--- a/js/utils/eventListeners/initializeSearchEvents.js
+++ b/js/utils/eventListeners/initializeSearchEvents.js
@@ -2,83 +2,81 @@ import { startSearch } from '../userActions/startSearch.js';
 import { searchState } from '../userActions/searchState.js';
 
 export default function initializeSearchEvents() {
-    // Add button for mobile
-    const mobileButton = document.createElement('button');
-    mobileButton.className = 'mobile-search-panel-button';
-    mobileButton.textContent = 'Search Panel';
+	// Add button for mobile
+	const mobileButton = document.createElement('button');
+	mobileButton.className = 'mobile-search-panel-button';
+	mobileButton.textContent = 'Search Panel';
 	const header_placeholder = document.getElementById('header-placeholder');
 	const hamburger = document.getElementById('hamburger-menu');
-    header_placeholder.insertBefore(mobileButton, hamburger);
-    
-    const optionPanel = document.getElementById('optionPanel');
-    const searchButton = document.getElementById('searchButton');
-    
-    // Function to close menu
-    const closeMenu = () => {
-        if (window.innerWidth <= 768) {
-            optionPanel.classList.remove('open');
-            mobileButton.classList.remove('open');
-        }
-    };
-    
-    // Handle menu open/close
-    mobileButton.addEventListener('click', () => {
-        optionPanel.classList.toggle('open');
-        mobileButton.classList.toggle('open');
-    });
-    
-    // Close the menu when the search button is clicked
-    searchButton.addEventListener('click', () => {
-        if (searchState.isSearching) {
-            searchState.shouldStopSearch = true;
-        } else {
-            startSearch();
-        }
-        closeMenu();
-    });
-    
-    // Handle window resizing
-    window.addEventListener('resize', () => {
-        if (window.innerWidth > 768) {
-            optionPanel.classList.remove('open');
-            mobileButton.classList.remove('open');
-        }
-    });
+	header_placeholder.insertBefore(mobileButton, hamburger);
 
-    const searchInput = document.getElementById('searchInput');
+	const optionPanel = document.getElementById('optionPanel');
+	const searchButton = document.getElementById('searchButton');
 
-    window.addEventListener("load", function() {
-        const searchInput = document.getElementById("searchInput");
-        const searchButton = document.getElementById("searchButton");
-        const langInputs = Array.from(document.querySelectorAll('input[name="lang"]'));
-        const categoryInputs = Array.from(document.querySelectorAll('input[name="book"]'));
+	// Function to close menu
+	const closeMenu = () => {
+		if (window.innerWidth <= 768) {
+			optionPanel.classList.remove('open');
+			mobileButton.classList.remove('open');
+		}
+	};
 
-        function checkInputs() {
-            const searchValue = searchInput.value.trim();
-            const isSearchInputValid = searchValue.length >= 3; // At least 3 characters
-            const isLangChecked = langInputs.some(input => input.checked);
-            const isCategoryChecked = categoryInputs.some(input => input.checked);
-            
-            searchButton.disabled = !(isSearchInputValid && isLangChecked && isCategoryChecked);
-        }
+	// Handle menu open/close
+	mobileButton.addEventListener('click', () => {
+		optionPanel.classList.toggle('open');
+		mobileButton.classList.toggle('open');
+	});
 
-        [...langInputs, ...categoryInputs].forEach(input => {
-            input.addEventListener("change", checkInputs);
-        });
+	// Close the menu when the search button is clicked
+	searchButton.addEventListener('click', () => {
+		if (searchState.isSearching) {
+			searchState.shouldStopSearch = true;
+		} else {
+			startSearch();
+		}
+		closeMenu();
+	});
 
-        searchInput.addEventListener("input", checkInputs);
-        checkInputs();
+	// Handle window resizing
+	window.addEventListener('resize', () => {
+		if (window.innerWidth > 768) {
+			optionPanel.classList.remove('open');
+			mobileButton.classList.remove('open');
+		}
+	});
 
-        document.addEventListener('keydown', function(event) {
-            if (event.key === 'Enter') {
-                if (!searchButton.disabled) {
-                    startSearch();
-                    closeMenu();
-                }
-                event.preventDefault();
-            }
-        });
-    });
+	const searchInput = document.getElementById("searchInput");
+	const langInputs = Array.from(document.querySelectorAll('input[name="lang"]'));
+	const categoryInputs = Array.from(document.querySelectorAll('input[name="book"]'));
 
-    window.onload = () => searchInput.focus();
+	function checkInputs() {
+		const searchValue = searchInput.value.trim();
+		const isSearchInputValid = searchValue.length >= 3; // At least 3 characters
+		const isLangChecked = langInputs.some(input => input.checked);
+		const isCategoryChecked = categoryInputs.some(input => input.checked);
+
+		searchButton.disabled = !(isSearchInputValid && isLangChecked && isCategoryChecked);
+	}
+
+	[...langInputs, ...categoryInputs].forEach(input => {
+		input.addEventListener("change", checkInputs);
+	});
+
+	searchInput.addEventListener("input", checkInputs);
+	checkInputs();
+
+	document.addEventListener('keydown', function(event) {
+		if (event.key === 'Enter') {
+			if (!searchButton.disabled) {
+				startSearch();
+				closeMenu();
+			}
+			event.preventDefault();
+		}
+	});
+
+	//Needs setTimeout for the focus() to work
+	setTimeout(function() {
+		searchInput.focus();
+	}, 0);
 }

--- a/js/utils/loadContent/activateEventListeners.js
+++ b/js/utils/loadContent/activateEventListeners.js
@@ -22,6 +22,7 @@ import initializeFuse from '../eventListeners/initializeFuse.js';
 import activateTopButtonsTouchAnimation from '../eventListeners/activateTopButtonsTouchAnimation.js';
 import { initializePaliToggle } from "../eventListeners/initializePaliToggle.js";
 import initializeSideBySide from "../eventListeners/initializeSideBySide.js";
+import initializeSearchEvents from "../eventListeners/initializeSearchEvents.js";
 
 export function activateEventListeners(availableSuttasJson)
 {
@@ -39,7 +40,6 @@ export function activateEventListeners(availableSuttasJson)
     activateHamburgerMenuButtons();
     activateSettingsButtons();
     initializePaliToggle();
-    
     activateTopButtonsTouchAnimation();
 	
     if (!window.location.href.endsWith("/bookmarks.html") 
@@ -55,5 +55,9 @@ export function activateEventListeners(availableSuttasJson)
         activateHandleTextSelection();
         activateYoutubePreview();
         initializeSideBySide();
+    }
+	
+    if(window.location.href.endsWith("/search-panel.html")){
+        initializeSearchEvents();
     }
 }

--- a/search-panel.js
+++ b/search-panel.js
@@ -1,4 +1,3 @@
-import { initializeSearchEvents } from './js/utils/eventListeners/initializeSearchEvents.js';
 import { searchSuttasWithStop } from './js/utils/contentSections/searchSuttasWithStop.js';
 import { startSearch } from './js/utils/userActions/startSearch.js';
 import { searchState } from './js/utils/userActions/searchState.js';
@@ -9,15 +8,3 @@ import { preventFlashing } from './js/utils/navigation/preventFlashing.js';
 window.startSearch = startSearch;
 window.searchSuttasWithStop = searchSuttasWithStop;
 window.searchState = searchState;
-
-// Initialize search events once the DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-	try {
-		initializeSearchEvents();
-	} catch (error) {
-		console.error('[ERROR] Something went wrong:', error);
-	}
-	finally {
-		preventFlashing();
-	}
-});


### PR DESCRIPTION
On mobile, whenever the mobile header gets hidden on the search panel page, the `Search Panel` button will follow and moves at the top of the screen, in place of the header.

Also, if the search panel is open and the mobile header is shown, the `Search Panel` button is displayed on top of the search panel, to resolve this in a simple manner I made it so the mobile header gets hidden whenever the user clicks on the `Search Panel` button.

closes #289 