### PR TITLE
Feature/update mobile header menu styling

### DIFF
--- a/index.css
+++ b/index.css
@@ -1515,7 +1515,7 @@ bookmarkButton {
   }
 
   .title {
-    font-size: 20px;
+    font-size: 18px;
     font-weight: normal;
   }
 
@@ -1539,7 +1539,7 @@ bookmarkButton {
     button {
       position: absolute;
       right: 15px;
-      top: 18px;
+      top: 17px;
       border: none;
       background-color: transparent;
     }
@@ -1592,7 +1592,7 @@ bookmarkButton {
     }
 
     * {
-      font-size: 20px;
+      font-size: 18px;
   
       a {
         display: flex;
@@ -1621,7 +1621,7 @@ bookmarkButton {
 
   .box-button {
     width: calc(100% - 40px);
-    margin: 20px auto;
+    margin: 15px auto;
     font-size: 16px;
     font-family: "RobotoSerif", serif;
   }
@@ -1682,6 +1682,7 @@ bookmarkButton {
   left: 10px;
   top: 1px;
   font-size: 16px !important;
+  font-family: "RobotoSerif", serif;
   color: white;
   display: none;
 }

--- a/js/utils/eventListeners/activateWindowEventListeners.js
+++ b/js/utils/eventListeners/activateWindowEventListeners.js
@@ -21,11 +21,14 @@ export default function activateWindowEventListeners() {
     window.addEventListener("scroll", () => {
       if (isTogglingPali) return; // Prevents the scroll event while toggling Pali
 
-      if (window.scrollY > lastScrollY) {
+      if (lastScrollY <= header?.offsetHeight) {
+        header.classList.remove("hidden");
+      } else if (window.scrollY > lastScrollY) {
         header.classList.add("hidden");
       } else {
         header.classList.remove("hidden");
       }
+  
       lastScrollY = window.scrollY;
     });
   }


### PR DESCRIPTION
@Reptilioo Have you noticed also the header disappearing on top when scrolling fast on mobile? I have had this happening on iOS device.

Changes:

- Attempt to fix mobile bug where header disppears when scrolling to top (cannot reproduce in browser when testing.)
- Decrease font-size of menu titles, slightly decrease margin for box-buttons. 
- Add "RobotoSerif" font for the tick, noticing this was displaying differently on iOS as well. See if this fixes it.

If ok with you it would be nice to merge it now so I can test it a bit further, I am not able to reproduce some issues in browser.