### PR TITLE
Fix typing in the filter field triggers shortcuts

### DIFF
--- a/js/utils/eventListeners/activateFilterBar.js
+++ b/js/utils/eventListeners/activateFilterBar.js
@@ -31,5 +31,10 @@ export default function activateFilterBar(availableSuttasJson) {
 
     filterForm.classList.remove("hide");
     displaySuttasLibrary(availableSuttasJson);
-  })
+  });
+
+  // Prevents shortcuts from triggering when typing in the filter
+  filterBar?.addEventListener("keyup", (e) => {
+    e.stopPropagation();
+  });
 }

--- a/js/utils/eventListeners/activateFilterForm.js
+++ b/js/utils/eventListeners/activateFilterForm.js
@@ -17,4 +17,9 @@ export default function activateFilterForm(){
     filterForm?.addEventListener('click', function () {
         filterBar.focus();
     });
+
+    // Prevents shortcuts from triggering when typing in the filter
+    filterForm?.addEventListener("keyup", (e) => {
+        e.stopPropagation();
+    });
 }

--- a/js/utils/eventListeners/activateFilterForm.js
+++ b/js/utils/eventListeners/activateFilterForm.js
@@ -17,9 +17,4 @@ export default function activateFilterForm(){
     filterForm?.addEventListener('click', function () {
         filterBar.focus();
     });
-
-    // Prevents shortcuts from triggering when typing in the filter
-    filterForm?.addEventListener("keyup", (e) => {
-        e.stopPropagation();
-    });
 }


### PR DESCRIPTION
This fixes a PC bug wherein the keyboard shortcuts trigger when you type in the filter.

For example, when you search for "**D**epen**d**ent Origination", dark mode will get toggled on and off every time you press "D".

This commit fixes it by adding stopPropagation in filter-form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented keyboard shortcuts from being triggered while typing in the filter bar, improving the user experience when filtering content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->