### PR TITLE
Fix shortcuts trigger when typing in input fields

### DIFF
--- a/js/utils/eventListeners/activateFilterBar.js
+++ b/js/utils/eventListeners/activateFilterBar.js
@@ -32,9 +32,4 @@ export default function activateFilterBar(availableSuttasJson) {
     filterForm.classList.remove("hide");
     displaySuttasLibrary(availableSuttasJson);
   });
-
-  // Prevents shortcuts from triggering when typing in the filter
-  filterBar?.addEventListener("keyup", (e) => {
-    e.stopPropagation();
-  });
 }

--- a/js/utils/eventListeners/activateStopInputKeyupPropagation.js
+++ b/js/utils/eventListeners/activateStopInputKeyupPropagation.js
@@ -1,0 +1,9 @@
+import getDocumentAreas from "../getDocumentAreas.js";
+
+export default function activateStopInputKeyupPropagation() {
+  const { filterBar, searchInput, newLabelInput } = getDocumentAreas();
+
+  filterBar?.addEventListener("keyup", (e) => e.stopPropagation());
+  searchInput?.addEventListener("keyup", (e) => e.stopPropagation());
+  newLabelInput?.addEventListener("keyup", (e) => e.stopPropagation());
+}

--- a/js/utils/getDocumentAreas.js
+++ b/js/utils/getDocumentAreas.js
@@ -39,5 +39,7 @@ export default function getDocumentAreas()
         shortcutsModal: document.getElementById("shortcuts-modal"),
         openButton: document.getElementById("shortcuts-button"),
         closeButton: document.getElementById("close-shortcuts"),
+        searchInput: document.getElementById("searchInput"),
+        newLabelInput: document.getElementById("newLabelInput"),
     }
 }

--- a/js/utils/loadContent/activateEventListeners.js
+++ b/js/utils/loadContent/activateEventListeners.js
@@ -24,6 +24,7 @@ import { initializePaliToggle } from "../eventListeners/initializePaliToggle.js"
 import initializeSideBySide from "../eventListeners/initializeSideBySide.js";
 import initializeSearchEvents from "../eventListeners/initializeSearchEvents.js";
 import activateSidebarToggles from "../eventListeners/activateSidebarToggles.js";
+import activateStopInputKeyupPropagation from "../eventListeners/activateStopInputKeyupPropagation.js";
 
 export function activateEventListeners(availableSuttasJson)
 {
@@ -44,6 +45,7 @@ export function activateEventListeners(availableSuttasJson)
     initializePaliToggle();
     activateTopButtonsTouchAnimation();
     activateShortcuts();
+    activateStopInputKeyupPropagation();
 	
     if (window.location.pathname === "/") {
         initializeFuse(availableSuttasJson);

--- a/js/utils/loadContent/activateEventListeners.js
+++ b/js/utils/loadContent/activateEventListeners.js
@@ -44,8 +44,8 @@ export function activateEventListeners(availableSuttasJson)
     activateSettingsButtons();
     initializePaliToggle();
     activateTopButtonsTouchAnimation();
-    activateShortcuts();
     activateStopInputKeyupPropagation();
+    activateShortcuts();
 	
     if (window.location.pathname === "/") {
         initializeFuse(availableSuttasJson);


### PR DESCRIPTION
Similar to #311 , I noticed that typing in other input fields also triggers shortcuts.

This fixes that by stopping those elements' keyup events from propagating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents global keyboard shortcuts from triggering while typing in the filter bar, search field, and new-label input.
  - Ensures consistent, predictable typing behavior across pages.

- Chores
  - Centralized input key handling so typing reliably stops shortcut propagation.
  - Updated initialization sequence to activate input key handling early during page load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->